### PR TITLE
a quick fix for mathjax

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -2532,6 +2532,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "1.2.63": {
+            "UpdateDate": 1727743018230,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 731,
+                    "Description": "a quick fix for mathjax"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1503,6 +1503,7 @@ async function main() {
                         localStorage.setItem("UserScript-Problem-" + Temp[i].children[1].innerText + "-Name", Temp[i].children[2].innerText);
                     }
                 } else if (location.pathname == "/problem.php") {
+                    RenderMathJax();
                     if (SearchParams.get("cid") != null) {
                         document.getElementsByTagName("h2")[0].innerHTML += " (" + localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-Problem-" + SearchParams.get("pid") + "-PID") + ")";
                     }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      1.2.62
+// @version      1.2.63
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "1.2.62",
+  "version": "1.2.63",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This pull request includes a small change to the `XMOJ.user.js` file. The change ensures that MathJax is rendered on the problem page.

**How does this PR accomplish the above?:**

* [`XMOJ.user.js`](diffhunk://#diff-dcd5dc88c3abdd0865e670a1d7e89a20c8d58bb15c59e095257105782de0a494R1506): Added a call to `RenderMathJax()` in the `async function main()` to render MathJax when the pathname is `/problem.php`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
