### PR TITLE
Fix code scanning alert - DOM text reinterpreted as HTML

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -2718,6 +2718,17 @@
                 }
             ],
             "Notes": "If you are curious why the version number is v1.3.0, it's because we changed our versioning strategy! Click <a href=\"https://github.com/orgs/XMOJ-Script-dev/discussions/771\"> here </a> for more details."
+        },
+        "1.3.1": {
+            "UpdateDate": 1739060055956,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 774,
+                    "Description": "Fix code scanning alert - DOM text reinterpreted as HTML"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -41,6 +41,19 @@
 const CaptchaSiteKey = "0x4AAAAAAALBT58IhyDViNmv";
 const AdminUserList = ["zhuchenrui2", "shanwenxiao", "admin"];
 
+let escapeHTML = (str) => {
+    return str.replace(/[&<>"']/g, function (match) {
+        const escape = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        };
+        return escape[match];
+    });
+};
+
 let PurifyHTML = (Input) => {
     try {
         return DOMPurify.sanitize(Input, {
@@ -3979,7 +3992,7 @@ int main()
                     Temp = document.querySelector("#problemstatus > tbody").children;
                     for (let i = 0; i < Temp.length; i++) {
                         if (Temp[i].children[5].children[0] != null) {
-                            Temp[i].children[1].innerHTML = `<a href="${Temp[i].children[5].children[0].href}">${Temp[i].children[1].innerText.trim()}</a>`;
+                            Temp[i].children[1].innerHTML = `<a href="${Temp[i].children[5].children[0].href}">${escapeHTML(Temp[i].children[1].innerText.trim())}</a>`;
                         }
                         GetUsernameHTML(Temp[i].children[2], Temp[i].children[2].innerText);
                         Temp[i].children[3].remove();

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      1.3.0
+// @version      1.3.1
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

 Fix code scanning alert - DOM text reinterpreted as HTML

**How does this PR accomplish the above?:**

* [`XMOJ.user.js`](diffhunk://#diff-dcd5dc88c3abdd0865e670a1d7e89a20c8d58bb15c59e095257105782de0a494R44-R56): Added an `escapeHTML` function to escape special HTML characters.
* [`XMOJ.user.js`](diffhunk://#diff-dcd5dc88c3abdd0865e670a1d7e89a20c8d58bb15c59e095257105782de0a494L3982-R3995): Updated the `main` function to use the `escapeHTML` function when setting innerHTML to prevent XSS attacks.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
9. I give this submission freely and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
