### PR TITLE
fix: Redirect to login page if profile element is missing

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -2873,6 +2873,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "1.7.3": {
+            "UpdateDate": 1750594769202,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 811,
+                    "Description": "fix: Redirect to login page if profile element is missing"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      1.7.2
+// @version      1.7.3
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -559,6 +559,9 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     let SearchParams = new URLSearchParams(location.search);
     let ServerURL = (UtilityEnabled("DebugMode") ? "https://ghpages.xmoj-bbs.me/" : "https://www.xmoj-bbs.me")
+    if (document.querySelector("#profile") === null) {
+        location.href = "https://www.xmoj.tech/loginpage.php";
+    }
     let CurrentUsername = document.querySelector("#profile").innerText;
     CurrentUsername = CurrentUsername.replaceAll(/[^a-zA-Z0-9]/g, "");
     let IsAdmin = AdminUserList.indexOf(CurrentUsername) !== -1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This pull request introduces a change to improve user experience by redirecting users to the login page if they are not logged in.
This closes #286.

**How does this PR accomplish the above?:**

* Added a check to determine if the `#profile` element is present on the page. If it is not found, the user is redirected to the login page at `https://www.xmoj.tech/loginpage.php`. (`XMOJ.user.js`, [XMOJ.user.jsR562-R564](diffhunk://#diff-dcd5dc88c3abdd0865e670a1d7e89a20c8d58bb15c59e095257105782de0a494R562-R564))

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
9. I give this submission freely and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
