### PR TITLE
fix: reinfo.php shows no test results even if test results are available

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -2903,6 +2903,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "1.8.1": {
+            "UpdateDate": 1751814421274,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 815,
+                    "Description": "fix: reinfo.php shows no test results even if test results are available"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3355,9 +3355,7 @@ window.addEventListener('DOMContentLoaded', async () => {
                         }
                     } else if (location.pathname == "/reinfo.php") {
                         document.title = "测试点信息: " + SearchParams.get("sid");
-                        if (document.querySelector("#results > div") == undefined) {
-                            document.querySelector("#results").parentElement.innerHTML = "没有测试点信息";
-                        } else {
+                        if (document.querySelector("#results > div") != undefined) {
                             for (let i = 0; i < document.querySelector("#results > div").children.length; i++) {
                                 let CurrentElement = document.querySelector("#results > div").children[i].children[0].children[0].children[0];
                                 let Temp = CurrentElement.innerText.substring(0, CurrentElement.innerText.length - 2).split("/");
@@ -3508,6 +3506,7 @@ int main()
                                 });
                             }
                         }
+                        document.body.innerHTML = String(document.body.innerHTML).replaceAll("<pre id=\"errtxt\" class=\"alert alert-error\">sorry , not available (,,,1)</pre>", "没有测试点信息");
                     } else if (location.pathname == "/downloads.php") {
                         let SoftwareList = document.querySelector("body > div > ul");
                         SoftwareList.remove();

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      1.8.0
+// @version      1.8.1
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

fix: reinfo.php shows no test results even if test results are available
Refer to https://support.xmoj-bbs.me/tickets/XS-16/5Zyo5pl55yL5rWL6KV54K56YCa6LH5oOF5Ya15pe25peg5rOV5pi56S65q2j56Gu5oOF5Ya1

**How does this PR accomplish the above?:**

### Improvements to test point information handling:

* Modified the conditional check in the `/reinfo.php` path to ensure proper handling when test point information is available. The code now iterates over elements only if they exist, improving reliability.

### Enhancements to error message display:

* Added a replacement mechanism in the `/downloads.php` path to replace the error message `<pre id="errtxt" class="alert alert-error">sorry , not available (,,,1)</pre>` with a more user-friendly message, "没有测试点信息."

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
9. I give this submission freely and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
