### PR TITLE
修复由于 PHPSESSID 启用了 httpOnly 导致的后台不可用

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3060,7 +3060,7 @@
             "Notes": "随着 CI 更新, 相信以后的 release 都会有 release notes("
         },
         "2.3.1": {
-            "UpdateDate": 1758944178711,
+            "UpdateDate": 1758944205783,
             "Prerelease": true,
             "UpdateContents": [
                 {
@@ -3068,7 +3068,7 @@
                     "Description": "修复由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
                 }
             ],
-            "Notes": "本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用\nThis fixes #847."
+            "Notes": "本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3060,7 +3060,7 @@
             "Notes": "随着 CI 更新, 相信以后的 release 都会有 release notes("
         },
         "2.3.1": {
-            "UpdateDate": 1758944137297,
+            "UpdateDate": 1758944178711,
             "Prerelease": true,
             "UpdateContents": [
                 {
@@ -3068,7 +3068,7 @@
                     "Description": "修复由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
                 }
             ],
-            "Notes": "本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
+            "Notes": "本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用\nThis fixes #847."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3058,6 +3058,17 @@
                 }
             ],
             "Notes": "随着 CI 更新, 相信以后的 release 都会有 release notes("
+        },
+        "2.3.1": {
+            "UpdateDate": 1758944137297,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 856,
+                    "Description": "修复由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
+                }
+            ],
+            "Notes": "本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用"
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      2.3.0
+// @version      2.3.1
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -20,6 +20,7 @@
 // @grant        unsafeWindow
 // @grant        GM_setValue
 // @grant        GM_getValue
+// @grant        GM_cookie
 // @homepage     https://www.xmoj-bbs.me/
 // @supportURL   https://support.xmoj-bbs.me/form/8050213e-c806-4680-b414-0d1c48263677
 // @connect      api.xmoj-bbs.tech
@@ -478,6 +479,20 @@ let RequestAPI = (Action, Data, CallBack) => {
             if (Temp[i].includes("PHPSESSID")) {
                 Session = Temp[i].split("=")[1];
             }
+        }
+        if (Session === "") { //The cookie is httpOnly
+            GM.cookie.set({
+                name: 'PHPSESSID',
+                value: Math.random().toString(36).substring(2, 15),
+                path: "/"
+            })
+                .then(() => {
+                    console.log('Reset PHPSESSID successfully.');
+                    location.reload(); //Refresh the page to auth with the new PHPSESSID
+                })
+                .catch((error) => {
+                    console.error(error);
+                });
         }
         let PostData = {
             "Authentication": {
@@ -1010,7 +1025,17 @@ async function main() {
                             });
                             PopupUL.children[5].addEventListener("click", () => {
                                 clearCredential();
-                                document.cookie = "PHPSESSID=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/"; //This is how you remove a cookie?
+                                GM.cookie.set({
+                                    name: 'PHPSESSID',
+                                    value: Math.random().toString(36).substring(2, 15),
+                                    path: "/"
+                                })
+                                    .then(() => {
+                                        console.log('Reset PHPSESSID successfully.');
+                                    })
+                                    .catch((error) => {
+                                        console.error(error);
+                                    }); //We can no longer rely of the server to set the cookie for us
                                 location.href = "https://www.xmoj.tech/logout.php";
                             });
                             Array.from(PopupUL.children).forEach(item => {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -483,7 +483,7 @@ let RequestAPI = (Action, Data, CallBack) => {
         if (Session === "") { //The cookie is httpOnly
             GM.cookie.set({
                 name: 'PHPSESSID',
-                value: Math.random().toString(36).substring(2, 15),
+                value: (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)).substring(0, 28),
                 path: "/"
             })
                 .then(() => {
@@ -1027,7 +1027,7 @@ async function main() {
                                 clearCredential();
                                 GM.cookie.set({
                                     name: 'PHPSESSID',
-                                    value: Math.random().toString(36).substring(2, 15),
+                                    value: (Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2)).substring(0, 28),
                                     path: "/"
                                 })
                                     .then(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!-- If you need to add release notes, put them here.-->
<!-- release-notes
本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用
-->

**What does this PR aim to accomplish?:**

本版本修复了由于 PHPSESSID 启用了 httpOnly 导致的后台不可用
This fixes #847.

**How does this PR accomplish the above?:**

Use `GM.cookie.set` to overwrite the httpOnly cookie with a one that we can access.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
9. I give this submission freely and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
