### PR TITLE
Release: XSS security fixes

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3370,6 +3370,21 @@
                 }
             ],
             "Notes": "Fixed additional stored XSS vulnerabilities where user-controlled data was inserted into innerHTML without sanitization."
+        },
+        "3.2.0": {
+            "UpdateDate": 1771493320789,
+            "Prerelease": false,
+            "UpdateContents": [
+                {
+                    "PR": 910,
+                    "Description": "Fix XSS in post title rendering"
+                },
+                {
+                    "PR": 911,
+                    "Description": "Fix additional XSS vulnerabilities"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.1.2
+// @version      3.2.0
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
Merge dev into master for security release.

Includes XSS fixes from #910 and #911 — sanitizing user-controlled data in innerHTML assignments across post titles, board names, usernames, and changelog descriptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitized user input before innerHTML to close stored XSS across threads, profiles, and changelog. Bumps version to 3.2.0 and updates Update.json with release entries for 3.1.1, 3.1.2, and 3.2.0.

- **Bug Fixes**
  - Escape post titles in thread list and thread view.
  - Escape board name in thread view.
  - Escape UserID and nickname on profile page.
  - Escape EditPerson in reply edit info.
  - Escape update descriptions in changelog.

<sup>Written for commit 95831316afb45f3dc85841c1a23af480a525c268. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

