### PR TITLE
Fix Problem Switcher Not Update

### DIFF
--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -533,6 +533,29 @@ let RequestAPI = (Action, Data, CallBack) => {
     }
 };
 
+unsafeWindow.GetContestProblemList = async function(RefreshList) {
+    try {
+        const contestReq = await fetch("https://www.xmoj.tech/contest.php?cid=" + SearchParams.get("cid"));
+        const res = await contestReq.text();
+        if (contestReq.status === 200 && res.indexOf("比赛尚未开始或私有，不能查看题目。") === -1) {
+            const parser = new DOMParser();
+            const dom = parser.parseFromString(res, "text/html");
+            const rows = (dom.querySelector("#problemset > tbody")).rows;
+            let problemList = [];
+            for (let i = 0; i < rows.length; i++) {
+                problemList.push({
+                    "title": rows[i].children[2].innerText,
+                    "url": rows[i].children[2].children[0].href
+                });
+            }
+            localStorage.setItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList", JSON.stringify(problemList));
+            if (RefreshList) location.reload();
+        }
+    } catch (e) {
+        console.error(e);
+    }
+}
+
 // WebSocket Notification System
 let NotificationSocket = null;
 let NotificationSocketReconnectAttempts = 0;
@@ -2270,22 +2293,8 @@ async function main() {
                         }
                         let ContestProblemList = localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList");
                         if (ContestProblemList == null) {
-                            const contestReq = await fetch("https://www.xmoj.tech/contest.php?cid=" + SearchParams.get("cid"));
-                            const res = await contestReq.text();
-                            if (contestReq.status === 200 && res.indexOf("比赛尚未开始或私有，不能查看题目。") === -1) {
-                                const parser = new DOMParser();
-                                const dom = parser.parseFromString(res, "text/html");
-                                const rows = (dom.querySelector("#problemset > tbody")).rows;
-                                let problemList = [];
-                                for (let i = 0; i < rows.length; i++) {
-                                    problemList.push({
-                                        "title": rows[i].children[2].innerText,
-                                        "url": rows[i].children[2].children[0].href
-                                    });
-                                }
-                                localStorage.setItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList", JSON.stringify(problemList));
-                                ContestProblemList = JSON.stringify(problemList);
-                            }
+                            unsafeWindow.GetContestProblemList(false);
+                            ContestProblemList = localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList");
                         }
 
                         let problemSwitcher = document.createElement("div");
@@ -2308,6 +2317,7 @@ async function main() {
                         problemSwitcher.style.flexDirection = "column";
 
                         let problemList = JSON.parse(ContestProblemList);
+                        problemSwitcher.innerHTML += `<a href="javascript:void(0)" onclick="GetContestProblemList(true)" title="刷新列表" class="mb-2" style="text-align: center;" active>刷新</a>`;
                         for (let i = 0; i < problemList.length; i++) {
                             let buttonText = "";
                             if (i < 26) {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md

Notes:
- Base your PR on the developmental branch (`dev`).
- Please use this pull request template, or your pull request will be closed.
- Use "Closes #123" to auto-link issues.
-->

<!-- If you need to add release notes, put them here.-->
<!-- release-notes
Fix ProblemSwitcher Not Update
-->

**What does this PR aim to accomplish?**

Fix *EX problems not display.

**How does this PR accomplish the above?**

Update list when click the refresh button. (The refresh button is located at the top of the problem switcher)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
9. I give this submission freely and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Bug Fixes:
- Fix contest problem list not updating by reloading data from the contest page when needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Problem Switcher not updating so new and EX problems show up after a manual refresh. Adds a refresh control that fetches the latest contest problem list and reloads the view.

- **Bug Fixes**
  - Introduced `GetContestProblemList` to parse the contest page, cache results in `localStorage`, and optionally reload.
  - Added a "刷新" link in the Problem Switcher that updates the list and reloads the page.
  - Replaced inline fetch logic with the shared helper to prevent stale data.

<sup>Written for commit cb969d2ff6bd72807ab9818601398fe7d13dd58a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

