### PR TITLE
feat: add refresh button to ProblemSwitcher

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3433,6 +3433,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "3.3.2": {
+            "UpdateDate": 1773497073852,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 934,
+                    "Description": "feat: add refresh button to ProblemSwitcher"
+                }
+            ],
+            "Notes": "Added a refresh button (↻) to the ProblemSwitcher panel. Clicking it invalidates the cached contest problem list and reloads the page, useful when contest problems are updated mid-contest."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3435,7 +3435,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.3.2": {
-            "UpdateDate": 1773497073852,
+            "UpdateDate": 1773497456666,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2323,24 +2323,29 @@ async function main() {
                             }
                             problemSwitcher.innerHTML += `<a href="${problemList[i].url}" title="${problemList[i].title.trim()}" class="btn btn-outline-secondary mb-2 ${activeClass}">${buttonText}</a>`;
                         }
+                        let refreshCid = SearchParams.get("cid");
                         let refreshBtn = document.createElement("a");
                         refreshBtn.title = "刷新缓存";
                         refreshBtn.classList.add("btn", "btn-outline-secondary", "mt-2");
                         refreshBtn.innerHTML = "↻";
                         refreshBtn.href = "#";
-                        refreshBtn.addEventListener("click", function(e) {
-                            e.preventDefault();
-                            let cid = SearchParams.get("cid");
-                            let keysToRemove = [];
-                            for (let k = 0; k < localStorage.length; k++) {
-                                let key = localStorage.key(k);
-                                if (key && key.startsWith("UserScript-Contest-" + cid + "-")) {
-                                    keysToRemove.push(key);
+                        if (refreshCid) {
+                            refreshBtn.addEventListener("click", function(e) {
+                                e.preventDefault();
+                                let prefix = "UserScript-Contest-" + refreshCid + "-";
+                                let keysToRemove = [];
+                                for (let k = 0; k < localStorage.length; k++) {
+                                    let key = localStorage.key(k);
+                                    if (key && key.startsWith(prefix)) {
+                                        keysToRemove.push(key);
+                                    }
                                 }
-                            }
-                            keysToRemove.forEach(k => localStorage.removeItem(k));
-                            location.reload();
-                        });
+                                keysToRemove.forEach(k => localStorage.removeItem(k));
+                                location.reload();
+                            });
+                        } else {
+                            refreshBtn.style.display = "none";
+                        }
                         problemSwitcher.appendChild(refreshBtn);
                         document.body.appendChild(problemSwitcher);
                     }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.1
+// @version      3.3.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2323,6 +2323,25 @@ async function main() {
                             }
                             problemSwitcher.innerHTML += `<a href="${problemList[i].url}" title="${problemList[i].title.trim()}" class="btn btn-outline-secondary mb-2 ${activeClass}">${buttonText}</a>`;
                         }
+                        let refreshBtn = document.createElement("a");
+                        refreshBtn.title = "刷新缓存";
+                        refreshBtn.classList.add("btn", "btn-outline-secondary", "mt-2");
+                        refreshBtn.innerHTML = "↻";
+                        refreshBtn.href = "#";
+                        refreshBtn.addEventListener("click", function(e) {
+                            e.preventDefault();
+                            let cid = SearchParams.get("cid");
+                            let keysToRemove = [];
+                            for (let k = 0; k < localStorage.length; k++) {
+                                let key = localStorage.key(k);
+                                if (key && key.startsWith("UserScript-Contest-" + cid + "-")) {
+                                    keysToRemove.push(key);
+                                }
+                            }
+                            keysToRemove.forEach(k => localStorage.removeItem(k));
+                            location.reload();
+                        });
+                        problemSwitcher.appendChild(refreshBtn);
                         document.body.appendChild(problemSwitcher);
                     }
                     if (document.querySelector("body > div > div.mt-3 > h2") != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds a `↻` (refresh) button at the bottom of the ProblemSwitcher panel
- Clicking it clears all `localStorage` cache entries for the current contest (`UserScript-Contest-{cid}-*`)
- Triggers a page reload so contest problem data is re-fetched fresh

Fixes #927

<!-- release-notes
Added a refresh button (↻) to the ProblemSwitcher panel. Clicking it invalidates the cached contest problem list and reloads the page, useful when contest problems are updated mid-contest.
-->

## Test plan

- [ ] Open a contest problem page with ProblemSwitcher enabled
- [ ] Verify the `↻` button appears at the bottom of the switcher panel
- [ ] Click the button and confirm `localStorage` entries for the contest are cleared
- [ ] Confirm the page reloads and problem data is re-fetched correctly
- [ ] Verify the switcher renders normally after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Add a refresh button to the ProblemSwitcher panel that clears contest-specific localStorage cache and reloads the page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a refresh (↻) button to the ProblemSwitcher that clears contest cache (`UserScript-Contest-{cid}-*`) and reloads the page to fetch a fresh problem list. Updated to 3.3.2 (prerelease) and refreshed release notes and timestamp in `Update.json`.

- **Refactors**
  - Hide the button when `cid` is missing to avoid accidental cache deletion.
  - Capture `cid` once and use a local `prefix` variable to simplify the handler.

<sup>Written for commit 31a03198d9a1da3b2dbaceec9f0a4e69f06491e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

