### PR TITLE
Display status.php Query Content

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3446,7 +3446,7 @@
             "Notes": "Fix ProblemSwitcher Not Update"
         },
         "3.3.3": {
-            "UpdateDate": 1773542354999,
+            "UpdateDate": 1773545950014,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3444,6 +3444,17 @@
                 }
             ],
             "Notes": "Fix ProblemSwitcher Not Update"
+        },
+        "3.3.3": {
+            "UpdateDate": 1773542354999,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 937,
+                    "Description": "Display status.php Query Content"
+                }
+            ],
+            "Notes": "Display status.php query content."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3446,7 +3446,7 @@
             "Notes": "Fix ProblemSwitcher Not Update"
         },
         "3.3.3": {
-            "UpdateDate": 1773545950014,
+            "UpdateDate": 1773550684270,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,10 +2526,11 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
-                            const params = new URLSearchParams(window.location.search);
-                            const CurrentProblemId = params.get('problem_id');
-                            const CurrentLanguage = params.get('language');
-                            const CurrentJresult = params.get('jresult');
+                            const params = new URL(location.href).searchParams;
+                            let nonDigitPattern = /D/;
+                            let CurrentProblemId = isNaN(params.get("problem_id")) ? "" : params.get("problem_id");
+                            let CurrentLanguage = isNaN(params.get("language")) || params.get("language") < -1 || params.get("language") > 2 ? "-1" : params.get("language");
+                            let CurrentJresult = isNaN(params.get("jresult")) || params.get("jresult") < -1 || params.get("jresult") > 11 ? "-1" : params.get("jresult");
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,16 +2526,28 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
+                            const url = window.location.href;
+                            const paramsRegex = /[?&]([^=#]+)=([^&#]*)/g;
+                            let match;
+                            let CurrentProblemId, CurrentLanguage, CurrentJresult;
+                            while ((match = paramsRegex.exec(url)) !== null) {
+                                const [_, key, value] = match;
+                                if (key == 'problem_id') CurrentProblemId = value;
+                                if (key == 'language') CurrentLanguage = value;
+                                if (key == 'jresult') CurrentJresult = value;
+                            }
+                            console.log(CurrentProblemId + '\n' + CurrentLanguage + '\n' + CurrentJresult);
+
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">
                 <div class="col-md-1">
                     <label for="problem_id" class="form-label">题目编号</label>
-                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4">
+                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4" value="${CurrentProblemId}">
                 </div>
                 <div class="col-md-1">
                     <label for="language" class="form-label">语言</label>
                     <select id="language" name="language" class="form-select">
-                        <option value="-1" selected="">全部</option>
+                        <option value="-1">全部</option>
                         <option value="0">C</option>
                         <option value="1">C++</option>
                         <option value="2">Pascal</option>
@@ -2543,7 +2555,7 @@ async function main() {
                 </div><div class="col-md-1">
                     <label for="jresult" class="form-label">结果</label>
                     <select id="jresult" name="jresult" class="form-select">
-                        <option value="-1" selected="">全部</option>
+                        <option value="-1">全部</option>
                         <option value="4">正确</option>
                         <option value="5">格式错误</option>
                         <option value="6">答案错误</option>
@@ -2561,6 +2573,11 @@ async function main() {
                 <div class="col-md-1">
                     <button type="submit" class="btn btn-primary">查找</button>
                 </div><div id="csrf"></div></form>`;
+
+                            var selectElement = document.getElementById('language');
+                            selectElement.value = CurrentLanguage;
+                            selectElement = document.getElementById('jresult');
+                            selectElement.value = CurrentJresult;
                         }
 
                         if (UtilityEnabled("ImproveACRate")) {
@@ -3298,8 +3315,8 @@ async function main() {
                                     }
                                     ErrorElement.style.display = "block";
                                     ErrorMessage.style.color = "red";
-                                    ErrorMessage.innerText = "比赛已结束, 正在尝试像题目 " + rPID + " 提交";
-                                    console.log("比赛已结束, 正在尝试像题目 " + rPID + " 提交");
+                                    ErrorMessage.innerText = "比赛已结束, 正在尝试向题目 " + rPID + " 提交";
+                                    console.log("比赛已结束, 正在尝试向题目 " + rPID + " 提交");
                                     let o2Switch = "&enable_O2=on";
                                     if (!document.querySelector("#enable_O2").checked) o2Switch = "";
                                     await fetch("https://www.xmoj.tech/submit.php", {
@@ -5602,13 +5619,13 @@ int main()
                     .xmoj-image-preview {
                         cursor: pointer;
                     }
-                    
+
                     .xmoj-image-preview:hover {
                         opacity: 0.8;
                         transition: opacity 0.2s ease;
                     }
-                    
-                    
+
+
                     .xmoj-image-modal {
                         display: none;
                         position: fixed;
@@ -5619,12 +5636,12 @@ int main()
                         height: 100%;
                         background-color: rgba(0, 0, 0, 0.9);
                     }
-                    
+
                     .xmoj-image-modal.show {
                         display: flex;
                         flex-direction: column;
                     }
-                    
+
                     .xmoj-image-modal-content {
                         flex: 1;
                         display: flex;
@@ -5633,13 +5650,13 @@ int main()
                         overflow: hidden;
                         position: relative;
                     }
-                    
+
                     .xmoj-image-modal-image {
                         max-width: 100%;
                         max-height: 100%;
                         object-fit: contain;
                     }
-                    
+
                     .xmoj-image-modal-toolbar {
                         display: flex;
                         justify-content: center;
@@ -5648,7 +5665,7 @@ int main()
                         background-color: rgba(0, 0, 0, 0.5);
                         flex-wrap: wrap;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button {
                         padding: 8px 16px;
                         background-color: #0d6efd;
@@ -5659,15 +5676,15 @@ int main()
                         font-size: 14px;
                         transition: background-color 0.2s ease;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button:hover {
                         background-color: #0b5ed7;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button:active {
                         background-color: #0a58ca;
                     }
-                    
+
                     .xmoj-image-modal-close {
                         position: absolute;
                         top: 20px;
@@ -5683,11 +5700,11 @@ int main()
                         transition: color 0.2s ease;
                         z-index: 1;
                     }
-                    
+
                     .xmoj-image-modal-close:hover {
                         color: #ccc;
                     }
-                    
+
                     .xmoj-image-modal-nav {
                         position: absolute;
                         top: 50%;
@@ -5702,33 +5719,33 @@ int main()
                         user-select: none;
                         -webkit-user-select: none;
                     }
-                    
+
                     .xmoj-image-modal-nav:hover {
                         background: rgba(0, 0, 0, 0.8);
                     }
-                    
+
                     .xmoj-image-modal-nav:disabled {
                         opacity: 0.3;
                         cursor: default;
                     }
-                    
+
                     .xmoj-image-modal-nav-prev {
                         left: 0;
                         border-radius: 0 4px 4px 0;
                     }
-                    
+
                     .xmoj-image-modal-nav-next {
                         right: 0;
                         border-radius: 4px 0 0 4px;
                     }
                 `;
                 document.head.appendChild(EnlargerStyle);
-                
+
                 // Create modal element
                 let ImageModal = document.createElement("div");
                 ImageModal.className = "xmoj-image-modal";
                 ImageModal.id = "xmoj-image-modal";
-                
+
                 let CloseButton = document.createElement("button");
                 CloseButton.className = "xmoj-image-modal-close";
                 CloseButton.type = "button";
@@ -5736,55 +5753,55 @@ int main()
                 CloseButton.title = "关闭图片";
                 CloseButton.innerHTML = "&times;";
                 ImageModal.appendChild(CloseButton);
-                
+
                 let ModalContent = document.createElement("div");
                 ModalContent.className = "xmoj-image-modal-content";
-                
+
                 let PrevBtn = document.createElement("button");
                 PrevBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-prev";
                 PrevBtn.type = "button";
                 PrevBtn.setAttribute("aria-label", "上一张");
                 PrevBtn.innerHTML = "&#10094;";
                 ModalContent.appendChild(PrevBtn);
-                
+
                 let NextBtn = document.createElement("button");
                 NextBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-next";
                 NextBtn.type = "button";
                 NextBtn.setAttribute("aria-label", "下一张");
                 NextBtn.innerHTML = "&#10095;";
                 ModalContent.appendChild(NextBtn);
-                
+
                 let ModalImage = document.createElement("img");
                 ModalImage.className = "xmoj-image-modal-image";
                 ModalContent.appendChild(ModalImage);
                 ImageModal.appendChild(ModalContent);
-                
+
                 let Toolbar = document.createElement("div");
                 Toolbar.className = "xmoj-image-modal-toolbar";
-                
+
                 let ZoomInBtn = document.createElement("button");
                 ZoomInBtn.innerHTML = "放大 (+)";
                 ZoomInBtn.type = "button";
                 Toolbar.appendChild(ZoomInBtn);
-                
+
                 let ZoomOutBtn = document.createElement("button");
                 ZoomOutBtn.innerHTML = "缩小 (-)";
                 ZoomOutBtn.type = "button";
                 Toolbar.appendChild(ZoomOutBtn);
-                
+
                 let ResetZoomBtn = document.createElement("button");
                 ResetZoomBtn.innerHTML = "重置大小";
                 ResetZoomBtn.type = "button";
                 Toolbar.appendChild(ResetZoomBtn);
-                
+
                 let SaveBtn = document.createElement("button");
                 SaveBtn.innerHTML = "保存图片";
                 SaveBtn.type = "button";
                 Toolbar.appendChild(SaveBtn);
-                
+
                 ImageModal.appendChild(Toolbar);
                 document.body.appendChild(ImageModal);
-                
+
                 // Zoom level and navigation state
                 let CurrentZoom = 1;
                 const ZoomStep = 0.1;
@@ -5804,7 +5821,7 @@ int main()
                 let TouchStartY = 0;
                 let TouchPanStartPanX = 0;
                 let TouchPanStartPanY = 0;
-                
+
                 // Function to update image transform (zoom + pan)
                 let UpdateImageSize = () => {
                     ModalImage.style.transform = `translate(${PanX}px, ${PanY}px) scale(${CurrentZoom})`;
@@ -5813,7 +5830,7 @@ int main()
                     ModalImage.style.cursor = CursorStyle;
                     ModalContent.style.cursor = CursorStyle;
                 };
-                
+
                 // Function to update prev/next button state
                 let UpdateNavButtons = () => {
                     let HasMultiple = ImageList.length > 1;
@@ -5822,7 +5839,7 @@ int main()
                     PrevBtn.disabled = CurrentImageIndex <= 0;
                     NextBtn.disabled = CurrentImageIndex >= ImageList.length - 1;
                 };
-                
+
                 // Function to navigate to a specific image by index
                 let NavigateTo = (index) => {
                     if (index < 0 || index >= ImageList.length) return;
@@ -5834,7 +5851,7 @@ int main()
                     UpdateNavButtons();
                     UpdateImageSize();
                 };
-                
+
                 // Function to open modal
                 let OpenImageModal = (imgElement) => {
                     let PreviewImages = [...document.querySelectorAll("img.xmoj-image-preview")];
@@ -5852,22 +5869,22 @@ int main()
                     UpdateNavButtons();
                     UpdateImageSize();
                 };
-                
+
                 // Function to close modal
                 let CloseImageModal = () => {
                     ImageModal.classList.remove("show");
                 };
-                
+
                 // Close button click
                 CloseButton.addEventListener("click", CloseImageModal);
-                
+
                 // Close when clicking outside the image
                 ImageModal.addEventListener("click", (e) => {
                     if (e.target === ImageModal || e.target === ModalContent) {
                         CloseImageModal();
                     }
                 });
-                
+
                 // Keyboard shortcuts
                 document.addEventListener("keydown", (e) => {
                     if (ImageModal.classList.contains("show")) {
@@ -5884,7 +5901,7 @@ int main()
                         }
                     }
                 });
-                
+
                 // Touch events: pan when zoomed, swipe to navigate when at zoom level 1
                 ModalContent.addEventListener("touchstart", (e) => {
                     if (e.touches.length !== 1) return;
@@ -5898,7 +5915,7 @@ int main()
                         IsTouchPanning = false;
                     }
                 }, { passive: true });
-                
+
                 ModalContent.addEventListener("touchmove", (e) => {
                     if (!IsTouchPanning || e.touches.length !== 1) return;
                     PanX = TouchPanStartPanX + (e.touches[0].clientX - TouchStartX);
@@ -5906,7 +5923,7 @@ int main()
                     UpdateImageSize();
                     e.preventDefault();
                 }, { passive: false });
-                
+
                 ModalContent.addEventListener("touchend", (e) => {
                     if (IsTouchPanning) {
                         IsTouchPanning = false;
@@ -5925,7 +5942,7 @@ int main()
                         }
                     }
                 }, { passive: true });
-                
+
                 // Mouse drag to pan when zoomed
                 ModalContent.addEventListener("mousedown", (e) => {
                     if (CurrentZoom <= 1) return;
@@ -5939,14 +5956,14 @@ int main()
                     ModalContent.style.cursor = "grabbing";
                     e.preventDefault();
                 });
-                
+
                 document.addEventListener("mousemove", (e) => {
                     if (!IsDragging) return;
                     PanX = DragStartPanX + (e.clientX - DragStartX);
                     PanY = DragStartPanY + (e.clientY - DragStartY);
                     UpdateImageSize();
                 });
-                
+
                 document.addEventListener("mouseup", () => {
                     if (IsDragging) {
                         IsDragging = false;
@@ -5955,7 +5972,7 @@ int main()
                         ModalContent.style.cursor = CursorStyle;
                     }
                 });
-                
+
                 // Mouse wheel to zoom in/out
                 ModalContent.addEventListener("wheel", (e) => {
                     e.preventDefault();
@@ -5963,36 +5980,36 @@ int main()
                     CurrentZoom = Math.max(MinZoom, Math.min(MaxZoom, CurrentZoom + ZoomDelta));
                     UpdateImageSize();
                 }, { passive: false });
-                
+
                 // Navigation button clicks
                 PrevBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
                     NavigateTo(CurrentImageIndex - 1);
                 });
-                
+
                 NextBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
                     NavigateTo(CurrentImageIndex + 1);
                 });
-                
+
                 // Zoom controls
                 ZoomInBtn.addEventListener("click", () => {
                     CurrentZoom = Math.min(CurrentZoom + ZoomStep, MaxZoom);
                     UpdateImageSize();
                 });
-                
+
                 ZoomOutBtn.addEventListener("click", () => {
                     CurrentZoom = Math.max(CurrentZoom - ZoomStep, MinZoom);
                     UpdateImageSize();
                 });
-                
+
                 ResetZoomBtn.addEventListener("click", () => {
                     CurrentZoom = 1;
                     PanX = 0;
                     PanY = 0;
                     UpdateImageSize();
                 });
-                
+
                 // Save/Download image: fetch via GM_xmlhttpRequest to bypass CORS, then use blob URL for reliable download
                 SaveBtn.addEventListener("click", () => {
                     let src = ModalImage.src;
@@ -6023,7 +6040,7 @@ int main()
                         }
                     });
                 });
-                
+
                 // Apply to all images on the page
                 let ApplyEnlargerToImage = (img) => {
                     const effectiveSrc = img.currentSrc || img.src;
@@ -6047,10 +6064,10 @@ int main()
                 let ApplyEnlargerToImages = () => {
                     document.querySelectorAll("img").forEach(ApplyEnlargerToImage);
                 };
-                
+
                 // Apply to existing images
                 ApplyEnlargerToImages();
-                
+
                 // Apply to dynamically added images
                 let Observer = new MutationObserver((mutations) => {
                     mutations.forEach((mutation) => {
@@ -6064,12 +6081,12 @@ int main()
                         });
                     });
                 });
-                
+
                 Observer.observe(document.body, {
                     childList: true,
                     subtree: true
                 });
-                
+
             } catch (e) {
                 console.error(e);
                 if (UtilityEnabled("DebugMode")) {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.2
+// @version      3.3.3
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,11 +2526,19 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
+                            var checkNum = function(str) {
+                                var patrn = /^[0-9]{1,20}$/;
+                                var ans = true;
+                                if (!patrn.exec(str)) ans = false;
+                                return ans;
+                            }
+
                             const params = new URL(location.href).searchParams;
-                            let nonDigitPattern = /D/;
-                            let CurrentProblemId = isNaN(params.get("problem_id")) ? "" : params.get("problem_id");
-                            let CurrentLanguage = isNaN(params.get("language")) || params.get("language") < -1 || params.get("language") > 2 ? "-1" : params.get("language");
-                            let CurrentJresult = isNaN(params.get("jresult")) || params.get("jresult") < -1 || params.get("jresult") > 11 ? "-1" : params.get("jresult");
+                            let CurrentProblemId = checkNum(params.get("problem_id")) ? Number(params.get("problem_id")) : "";
+                            let CurrentLanguageParam = params.get("language");
+                            let CurrentLanguage = checkNum(CurrentLanguageParam) && -1 <= CurrentLanguageParam && CurrentLanguageParam <= 2 ? Number(CurrentLanguageParam) : "-1";
+                            let CurrentJresultParam = params.get("jresult");
+                            let CurrentJresult = checkNum(CurrentJresultParam) && -1 <= CurrentJresultParam && CurrentJresultParam <= 11 ? Number(CurrentJresultParam) : "-1";
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.3
+// @version      3.3.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen
@@ -2526,23 +2526,16 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
-                            const url = window.location.href;
-                            const paramsRegex = /[?&]([^=#]+)=([^&#]*)/g;
-                            let match;
-                            let CurrentProblemId, CurrentLanguage, CurrentJresult;
-                            while ((match = paramsRegex.exec(url)) !== null) {
-                                const [_, key, value] = match;
-                                if (key == 'problem_id') CurrentProblemId = value;
-                                if (key == 'language') CurrentLanguage = value;
-                                if (key == 'jresult') CurrentJresult = value;
-                            }
-                            console.log(CurrentProblemId + '\n' + CurrentLanguage + '\n' + CurrentJresult);
+                            const params = new URLSearchParams(window.location.search);
+                            const CurrentProblemId = params.get('problem_id');
+                            const CurrentLanguage = params.get('language');
+                            const CurrentJresult = params.get('jresult');
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">
                 <div class="col-md-1">
                     <label for="problem_id" class="form-label">题目编号</label>
-                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4" value="${CurrentProblemId}">
+                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4">
                 </div>
                 <div class="col-md-1">
                     <label for="language" class="form-label">语言</label>
@@ -2574,7 +2567,9 @@ async function main() {
                     <button type="submit" class="btn btn-primary">查找</button>
                 </div><div id="csrf"></div></form>`;
 
-                            var selectElement = document.getElementById('language');
+                            var selectElement = document.getElementById('problem_id');
+                            selectElement.value = CurrentProblemId;
+                            selectElement = document.getElementById('language');
                             selectElement.value = CurrentLanguage;
                             selectElement = document.getElementById('jresult');
                             selectElement.value = CurrentJresult;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md

Notes:
- Base your PR on the developmental branch (`dev`).
- Please use this pull request template, or your pull request will be closed.
- Use "Closes #123" to auto-link issues.
-->

<!-- If you need to add release notes, put them here.-->
<!-- release-notes
Display status.php query content.
-->

**What does this PR aim to accomplish?**

Display [status.php](https://www.xmoj.tech/status.php) query content.

**How does this PR accomplish the above?**

Get URL parameters and fill them into the query form.

---
<!-- If you are an LLM or AI assistant filling out this template: do NOT blindly tick boxes or confirm items without actually verifying them. Read each item carefully and only confirm what you have genuinely done. For item 11 specifically, you cannot test in a browser yourself — flag this to the human and ask them to verify the changes work in both the new UI and the old/classic XMOJ UI before checking that box. -->
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code.
3. I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
10. I give this submission freely and claim no ownership to its content.
11. I have verified that my changes work correctly in **both the new UI and the old/classic UI**.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Prefill the status query form from URL parameters in the new bootstrap UI and correct a user-facing submission message.

New Features:
- Populate the status.php query form fields from URL query parameters in the new bootstrap-enabled status page.

Bug Fixes:
- Fix a typo in the contest-ended submission message text shown to users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefills the `status.php` query form from URL parameters in the NewBootstrap UI so shared links open with the same filters. Adds numeric range checks, fixes XSS and special-value filling issues, removes stray logs, and updates to `3.3.3`.

- **New Features**
  - On `status.php` with `NewBootstrap`, read `problem_id`, `language`, and `jresult` from the URL, validate ranges, and set the form fields.

- **Bug Fixes**
  - Fixed an XSS on the status page and removed irrelevant console logs.
  - Fixed cases where certain special query values wouldn’t populate; corrected the contest-ended submission message ("向题目", not "像题目").

<sup>Written for commit ac131134b5614df88bd223beefad6a4a6034fa82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

