### PR TITLE
fix: gate MonochromeUI-specific styling in contestrank pages behind flag

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3457,7 +3457,7 @@
             "Notes": "Display status.php query content."
         },
         "3.3.4": {
-            "UpdateDate": 1773559847015,
+            "UpdateDate": 1773559861504,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3455,6 +3455,17 @@
                 }
             ],
             "Notes": "Display status.php query content."
+        },
+        "3.3.4": {
+            "UpdateDate": 1773559847015,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 939,
+                    "Description": "fix: gate MonochromeUI-specific styling in contestrank pages behind flag"
+                }
+            ],
+            "Notes": "修复了未开启「极简黑白界面风格」时，比赛排行榜表头仍显示为黑白样式的问题 (#932)"
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.3
+// @version      3.3.4
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3043,13 +3043,15 @@ async function main() {
                             HeaderCells[2].innerText = "昵称";
                             HeaderCells[3].innerText = "AC数";
                             HeaderCells[4].innerText = "得分";
-                            for (let j = 0; j < HeaderCells.length; j++) {
-                                HeaderCells[j].removeAttribute("bgcolor");
-                                HeaderCells[j].style.setProperty("background-color", "black", "important");
-                                HeaderCells[j].style.setProperty("color", "white", "important");
-                                let Links = HeaderCells[j].querySelectorAll("a");
-                                for (let k = 0; k < Links.length; k++) {
-                                    Links[k].style.setProperty("color", "white", "important");
+                            if (UtilityEnabled("MonochromeUI")) {
+                                for (let j = 0; j < HeaderCells.length; j++) {
+                                    HeaderCells[j].removeAttribute("bgcolor");
+                                    HeaderCells[j].style.setProperty("background-color", "black", "important");
+                                    HeaderCells[j].style.setProperty("color", "white", "important");
+                                    let Links = HeaderCells[j].querySelectorAll("a");
+                                    for (let k = 0; k < Links.length; k++) {
+                                        Links[k].style.setProperty("color", "white", "important");
+                                    }
                                 }
                             }
                             let RefreshOIRank = async () => {
@@ -3062,7 +3064,9 @@ async function main() {
                                         TidyTable(ParsedDocument.getElementById("rank"));
                                         let Temp = ParsedDocument.getElementById("rank").rows;
                                         for (var i = 1; i < Temp.length; i++) {
-                                            Temp[i].style.backgroundColor = "";
+                                            if (UtilityEnabled("MonochromeUI")) {
+                                                Temp[i].style.backgroundColor = "";
+                                            }
                                             let MetalCell = Temp[i].cells[0];
                                             let Metal = document.createElement("span");
                                             Metal.innerText = MetalCell.innerText;
@@ -3072,9 +3076,11 @@ async function main() {
                                             GetUsernameHTML(Temp[i].cells[1], Temp[i].cells[1].innerText);
                                             Temp[i].cells[2].innerHTML = Temp[i].cells[2].innerText;
                                             Temp[i].cells[3].innerHTML = Temp[i].cells[3].innerText;
-                                            for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
-                                                Temp[i].cells[j].style.backgroundColor = "";
-                                                Temp[i].cells[j].style.color = "";
+                                            if (UtilityEnabled("MonochromeUI")) {
+                                                for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
+                                                    Temp[i].cells[j].style.backgroundColor = "";
+                                                    Temp[i].cells[j].style.color = "";
+                                                }
                                             }
                                             for (let j = 5; j < Temp[i].cells.length; j++) {
                                                 let InnerText = Temp[i].cells[j].innerText;
@@ -3144,13 +3150,15 @@ async function main() {
                         HeaderCells[2].innerText = "昵称";
                         HeaderCells[3].innerText = "AC数";
                         HeaderCells[4].innerText = "得分";
-                        for (let j = 0; j < HeaderCells.length; j++) {
-                            HeaderCells[j].removeAttribute("bgcolor");
-                            HeaderCells[j].style.setProperty("background-color", "black", "important");
-                            HeaderCells[j].style.setProperty("color", "white", "important");
-                            let Links = HeaderCells[j].querySelectorAll("a");
-                            for (let k = 0; k < Links.length; k++) {
-                                Links[k].style.setProperty("color", "white", "important");
+                        if (UtilityEnabled("MonochromeUI")) {
+                            for (let j = 0; j < HeaderCells.length; j++) {
+                                HeaderCells[j].removeAttribute("bgcolor");
+                                HeaderCells[j].style.setProperty("background-color", "black", "important");
+                                HeaderCells[j].style.setProperty("color", "white", "important");
+                                let Links = HeaderCells[j].querySelectorAll("a");
+                                for (let k = 0; k < Links.length; k++) {
+                                    Links[k].style.setProperty("color", "white", "important");
+                                }
                             }
                         }
                         let RefreshCorrectRank = async () => {
@@ -3163,7 +3171,9 @@ async function main() {
                                     TidyTable(ParsedDocument.getElementById("rank"));
                                     let Temp = ParsedDocument.getElementById("rank").rows;
                                     for (var i = 1; i < Temp.length; i++) {
-                                        Temp[i].style.backgroundColor = "";
+                                        if (UtilityEnabled("MonochromeUI")) {
+                                            Temp[i].style.backgroundColor = "";
+                                        }
                                         let MetalCell = Temp[i].cells[0];
                                         let Metal = document.createElement("span");
                                         Metal.innerText = MetalCell.innerText;
@@ -3173,9 +3183,11 @@ async function main() {
                                         GetUsernameHTML(Temp[i].cells[1], Temp[i].cells[1].innerText);
                                         Temp[i].cells[2].innerHTML = Temp[i].cells[2].innerText;
                                         Temp[i].cells[3].innerHTML = Temp[i].cells[3].innerText;
-                                        for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
-                                            Temp[i].cells[j].style.backgroundColor = "";
-                                            Temp[i].cells[j].style.color = "";
+                                        if (UtilityEnabled("MonochromeUI")) {
+                                            for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
+                                                Temp[i].cells[j].style.backgroundColor = "";
+                                                Temp[i].cells[j].style.color = "";
+                                            }
                                         }
                                         for (let j = 5; j < Temp[i].cells.length; j++) {
                                             let InnerText = Temp[i].cells[j].innerText;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
## 概要 Summary

Fixes #932.

`contestrank-oi.php` 和 `contestrank-correct.php` 的黑白极简模式专属样式（表头黑底白字强制样式、行内联样式清除）现在只在开启「极简黑白界面风格」时生效。

The MonochromeUI-specific styling on `contestrank-oi.php` and `contestrank-correct.php` (black/white header forcing, inline style clearing) is now gated behind `UtilityEnabled("MonochromeUI")`. Badge ranks, color-coded cells, and auto-refresh remain unconditional.

## 变更内容 Changes

- Gate header `background-color: black !important` / `color: white !important` forcing under `MonochromeUI`
- Gate `Temp[i].style.backgroundColor = ""` row clearing under `MonochromeUI`
- Gate first-5-cells style clearing under `MonochromeUI`
- Applies to both `contestrank-oi.php` and `contestrank-correct.php`

## 测试 Test plan

- [x] 关闭「极简黑白界面风格」，访问比赛排行榜，确认表头不再强制黑白样式
- [x] 开启「极简黑白界面风格」，访问比赛排行榜，确认表头正常显示黑白样式
- [x] 两种情况下，名次徽章、色块和自动刷新功能正常工作

<!-- release-notes
修复了未开启「极简黑白界面风格」时，比赛排行榜表头仍显示为黑白样式的问题 (#932)
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure contest rank table headers and row style clearing only apply when the MonochromeUI option is enabled, so standard themes no longer get forced black-and-white styling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate MonochromeUI-specific styling behind the feature flag on contest rank pages to stop forced black/white headers when the theme is off. On `contestrank-oi.php` and `contestrank-correct.php`, header color forcing and inline style clearing now run only if `UtilityEnabled("MonochromeUI")`; badges, color cells, and auto-refresh stay as-is, and the script version updates to `3.3.4` (prerelease) with notes.

<sup>Written for commit d07172e30934db7dc90c131041527251b3263f69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

