### PR TITLE
Dev

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3466,6 +3466,17 @@
                 }
             ],
             "Notes": "修复了未开启「极简黑白界面风格」时，比赛排行榜表头仍显示为黑白样式的问题 (#932)"
+        },
+        "3.3.5": {
+            "UpdateDate": 1773559861504,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 948,
+                    "Description": "Remove problem translate button"
+                }
+            ],
+            "Notes": ""
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3424,7 +3424,7 @@
             "Notes": "<b>Bug 修复</b><br>\n- 修复了暗色模式下比赛排名表（contestrank-oi.php 和 contestrank-correct.php）颜色显示异常的问题（#916）<br>\n- 修复了 WebSocket 弹窗通知未遵循各功能独立弹窗开关（BBSPopup/MessagePopup）的问题（#919）"
         },
         "3.3.1": {
-            "UpdateDate": 1772847350873,
+            "UpdateDate": 1772981411290,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3446,7 +3446,7 @@
             "Notes": "Fix ProblemSwitcher Not Update"
         },
         "3.3.3": {
-            "UpdateDate": 1773542354999,
+            "UpdateDate": 1773545950014,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3422,6 +3422,17 @@
                 }
             ],
             "Notes": "<b>Bug 修复</b><br>\n- 修复了暗色模式下比赛排名表（contestrank-oi.php 和 contestrank-correct.php）颜色显示异常的问题（#916）<br>\n- 修复了 WebSocket 弹窗通知未遵循各功能独立弹窗开关（BBSPopup/MessagePopup）的问题（#919）"
+        },
+        "3.3.1": {
+            "UpdateDate": 1772845758104,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 924,
+                    "Description": "Add ImageEnlarger feature with modal viewer"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3457,7 +3457,7 @@
             "Notes": "Display status.php query content."
         },
         "3.3.4": {
-            "UpdateDate": 1773559847015,
+            "UpdateDate": 1773559861504,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3424,7 +3424,7 @@
             "Notes": "<b>Bug 修复</b><br>\n- 修复了暗色模式下比赛排名表（contestrank-oi.php 和 contestrank-correct.php）颜色显示异常的问题（#916）<br>\n- 修复了 WebSocket 弹窗通知未遵循各功能独立弹窗开关（BBSPopup/MessagePopup）的问题（#919）"
         },
         "3.3.1": {
-            "UpdateDate": 1772845758104,
+            "UpdateDate": 1772847350873,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3476,7 +3476,7 @@
                     "Description": "Remove problem translate button"
                 }
             ],
-            "Notes": ""
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3444,6 +3444,17 @@
                 }
             ],
             "Notes": "Fix ProblemSwitcher Not Update"
+        },
+        "3.3.3": {
+            "UpdateDate": 1773542354999,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 937,
+                    "Description": "Display status.php Query Content"
+                }
+            ],
+            "Notes": "Display status.php query content."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3433,6 +3433,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "3.3.2": {
+            "UpdateDate": 1773495619873,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 933,
+                    "Description": "Fix problem switcher not update"
+                }
+            ],
+            "Notes": "Fix ProblemSwitcher Not Update"
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3446,7 +3446,7 @@
             "Notes": "Fix ProblemSwitcher Not Update"
         },
         "3.3.3": {
-            "UpdateDate": 1773545950014,
+            "UpdateDate": 1773550684270,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3455,6 +3455,17 @@
                 }
             ],
             "Notes": "Display status.php query content."
+        },
+        "3.3.4": {
+            "UpdateDate": 1773559847015,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 939,
+                    "Description": "fix: gate MonochromeUI-specific styling in contestrank pages behind flag"
+                }
+            ],
+            "Notes": "修复了未开启「极简黑白界面风格」时，比赛排行榜表头仍显示为黑白样式的问题 (#932)"
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,10 +2526,11 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
-                            const params = new URLSearchParams(window.location.search);
-                            const CurrentProblemId = params.get('problem_id');
-                            const CurrentLanguage = params.get('language');
-                            const CurrentJresult = params.get('jresult');
+                            const params = new URL(location.href).searchParams;
+                            let nonDigitPattern = /D/;
+                            let CurrentProblemId = isNaN(params.get("problem_id")) ? "" : params.get("problem_id");
+                            let CurrentLanguage = isNaN(params.get("language")) || params.get("language") < -1 || params.get("language") > 2 ? "-1" : params.get("language");
+                            let CurrentJresult = isNaN(params.get("jresult")) || params.get("jresult") < -1 || params.get("jresult") > 11 ? "-1" : params.get("jresult");
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.0
+// @version      3.3.1
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5792,17 +5792,18 @@ int main()
                 
                 // Apply to all images on the page
                 let ApplyEnlargerToImage = (img) => {
-                    if (!img.classList.contains("xmoj-image-preview") && 
+                    const effectiveSrc = img.currentSrc || img.src;
+                    if (!img.classList.contains("xmoj-image-preview") &&
                         !img.closest(".xmoj-image-modal") &&
-                        img.src && 
-                        !img.src.includes("gravatar") &&
-                        !img.src.includes("cravatar")) {
-                        
+                        effectiveSrc &&
+                        !effectiveSrc.includes("gravatar") &&
+                        !effectiveSrc.includes("cravatar")) {
+
                         img.classList.add("xmoj-image-preview");
                         img.title = "点击放大";
                         img.addEventListener("click", (e) => {
                             e.stopPropagation();
-                            OpenImageModal(img.currentSrc || img.src);
+                            OpenImageModal(effectiveSrc);
                         });
                     }
                 };

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,16 +2526,28 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
+                            const url = window.location.href;
+                            const paramsRegex = /[?&]([^=#]+)=([^&#]*)/g;
+                            let match;
+                            let CurrentProblemId, CurrentLanguage, CurrentJresult;
+                            while ((match = paramsRegex.exec(url)) !== null) {
+                                const [_, key, value] = match;
+                                if (key == 'problem_id') CurrentProblemId = value;
+                                if (key == 'language') CurrentLanguage = value;
+                                if (key == 'jresult') CurrentJresult = value;
+                            }
+                            console.log(CurrentProblemId + '\n' + CurrentLanguage + '\n' + CurrentJresult);
+
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">
                 <div class="col-md-1">
                     <label for="problem_id" class="form-label">题目编号</label>
-                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4">
+                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4" value="${CurrentProblemId}">
                 </div>
                 <div class="col-md-1">
                     <label for="language" class="form-label">语言</label>
                     <select id="language" name="language" class="form-select">
-                        <option value="-1" selected="">全部</option>
+                        <option value="-1">全部</option>
                         <option value="0">C</option>
                         <option value="1">C++</option>
                         <option value="2">Pascal</option>
@@ -2543,7 +2555,7 @@ async function main() {
                 </div><div class="col-md-1">
                     <label for="jresult" class="form-label">结果</label>
                     <select id="jresult" name="jresult" class="form-select">
-                        <option value="-1" selected="">全部</option>
+                        <option value="-1">全部</option>
                         <option value="4">正确</option>
                         <option value="5">格式错误</option>
                         <option value="6">答案错误</option>
@@ -2561,6 +2573,11 @@ async function main() {
                 <div class="col-md-1">
                     <button type="submit" class="btn btn-primary">查找</button>
                 </div><div id="csrf"></div></form>`;
+
+                            var selectElement = document.getElementById('language');
+                            selectElement.value = CurrentLanguage;
+                            selectElement = document.getElementById('jresult');
+                            selectElement.value = CurrentJresult;
                         }
 
                         if (UtilityEnabled("ImproveACRate")) {
@@ -3298,8 +3315,8 @@ async function main() {
                                     }
                                     ErrorElement.style.display = "block";
                                     ErrorMessage.style.color = "red";
-                                    ErrorMessage.innerText = "比赛已结束, 正在尝试像题目 " + rPID + " 提交";
-                                    console.log("比赛已结束, 正在尝试像题目 " + rPID + " 提交");
+                                    ErrorMessage.innerText = "比赛已结束, 正在尝试向题目 " + rPID + " 提交";
+                                    console.log("比赛已结束, 正在尝试向题目 " + rPID + " 提交");
                                     let o2Switch = "&enable_O2=on";
                                     if (!document.querySelector("#enable_O2").checked) o2Switch = "";
                                     await fetch("https://www.xmoj.tech/submit.php", {
@@ -5602,13 +5619,13 @@ int main()
                     .xmoj-image-preview {
                         cursor: pointer;
                     }
-                    
+
                     .xmoj-image-preview:hover {
                         opacity: 0.8;
                         transition: opacity 0.2s ease;
                     }
-                    
-                    
+
+
                     .xmoj-image-modal {
                         display: none;
                         position: fixed;
@@ -5619,12 +5636,12 @@ int main()
                         height: 100%;
                         background-color: rgba(0, 0, 0, 0.9);
                     }
-                    
+
                     .xmoj-image-modal.show {
                         display: flex;
                         flex-direction: column;
                     }
-                    
+
                     .xmoj-image-modal-content {
                         flex: 1;
                         display: flex;
@@ -5633,13 +5650,13 @@ int main()
                         overflow: hidden;
                         position: relative;
                     }
-                    
+
                     .xmoj-image-modal-image {
                         max-width: 100%;
                         max-height: 100%;
                         object-fit: contain;
                     }
-                    
+
                     .xmoj-image-modal-toolbar {
                         display: flex;
                         justify-content: center;
@@ -5648,7 +5665,7 @@ int main()
                         background-color: rgba(0, 0, 0, 0.5);
                         flex-wrap: wrap;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button {
                         padding: 8px 16px;
                         background-color: #0d6efd;
@@ -5659,15 +5676,15 @@ int main()
                         font-size: 14px;
                         transition: background-color 0.2s ease;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button:hover {
                         background-color: #0b5ed7;
                     }
-                    
+
                     .xmoj-image-modal-toolbar button:active {
                         background-color: #0a58ca;
                     }
-                    
+
                     .xmoj-image-modal-close {
                         position: absolute;
                         top: 20px;
@@ -5683,11 +5700,11 @@ int main()
                         transition: color 0.2s ease;
                         z-index: 1;
                     }
-                    
+
                     .xmoj-image-modal-close:hover {
                         color: #ccc;
                     }
-                    
+
                     .xmoj-image-modal-nav {
                         position: absolute;
                         top: 50%;
@@ -5702,33 +5719,33 @@ int main()
                         user-select: none;
                         -webkit-user-select: none;
                     }
-                    
+
                     .xmoj-image-modal-nav:hover {
                         background: rgba(0, 0, 0, 0.8);
                     }
-                    
+
                     .xmoj-image-modal-nav:disabled {
                         opacity: 0.3;
                         cursor: default;
                     }
-                    
+
                     .xmoj-image-modal-nav-prev {
                         left: 0;
                         border-radius: 0 4px 4px 0;
                     }
-                    
+
                     .xmoj-image-modal-nav-next {
                         right: 0;
                         border-radius: 4px 0 0 4px;
                     }
                 `;
                 document.head.appendChild(EnlargerStyle);
-                
+
                 // Create modal element
                 let ImageModal = document.createElement("div");
                 ImageModal.className = "xmoj-image-modal";
                 ImageModal.id = "xmoj-image-modal";
-                
+
                 let CloseButton = document.createElement("button");
                 CloseButton.className = "xmoj-image-modal-close";
                 CloseButton.type = "button";
@@ -5736,55 +5753,55 @@ int main()
                 CloseButton.title = "关闭图片";
                 CloseButton.innerHTML = "&times;";
                 ImageModal.appendChild(CloseButton);
-                
+
                 let ModalContent = document.createElement("div");
                 ModalContent.className = "xmoj-image-modal-content";
-                
+
                 let PrevBtn = document.createElement("button");
                 PrevBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-prev";
                 PrevBtn.type = "button";
                 PrevBtn.setAttribute("aria-label", "上一张");
                 PrevBtn.innerHTML = "&#10094;";
                 ModalContent.appendChild(PrevBtn);
-                
+
                 let NextBtn = document.createElement("button");
                 NextBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-next";
                 NextBtn.type = "button";
                 NextBtn.setAttribute("aria-label", "下一张");
                 NextBtn.innerHTML = "&#10095;";
                 ModalContent.appendChild(NextBtn);
-                
+
                 let ModalImage = document.createElement("img");
                 ModalImage.className = "xmoj-image-modal-image";
                 ModalContent.appendChild(ModalImage);
                 ImageModal.appendChild(ModalContent);
-                
+
                 let Toolbar = document.createElement("div");
                 Toolbar.className = "xmoj-image-modal-toolbar";
-                
+
                 let ZoomInBtn = document.createElement("button");
                 ZoomInBtn.innerHTML = "放大 (+)";
                 ZoomInBtn.type = "button";
                 Toolbar.appendChild(ZoomInBtn);
-                
+
                 let ZoomOutBtn = document.createElement("button");
                 ZoomOutBtn.innerHTML = "缩小 (-)";
                 ZoomOutBtn.type = "button";
                 Toolbar.appendChild(ZoomOutBtn);
-                
+
                 let ResetZoomBtn = document.createElement("button");
                 ResetZoomBtn.innerHTML = "重置大小";
                 ResetZoomBtn.type = "button";
                 Toolbar.appendChild(ResetZoomBtn);
-                
+
                 let SaveBtn = document.createElement("button");
                 SaveBtn.innerHTML = "保存图片";
                 SaveBtn.type = "button";
                 Toolbar.appendChild(SaveBtn);
-                
+
                 ImageModal.appendChild(Toolbar);
                 document.body.appendChild(ImageModal);
-                
+
                 // Zoom level and navigation state
                 let CurrentZoom = 1;
                 const ZoomStep = 0.1;
@@ -5804,7 +5821,7 @@ int main()
                 let TouchStartY = 0;
                 let TouchPanStartPanX = 0;
                 let TouchPanStartPanY = 0;
-                
+
                 // Function to update image transform (zoom + pan)
                 let UpdateImageSize = () => {
                     ModalImage.style.transform = `translate(${PanX}px, ${PanY}px) scale(${CurrentZoom})`;
@@ -5813,7 +5830,7 @@ int main()
                     ModalImage.style.cursor = CursorStyle;
                     ModalContent.style.cursor = CursorStyle;
                 };
-                
+
                 // Function to update prev/next button state
                 let UpdateNavButtons = () => {
                     let HasMultiple = ImageList.length > 1;
@@ -5822,7 +5839,7 @@ int main()
                     PrevBtn.disabled = CurrentImageIndex <= 0;
                     NextBtn.disabled = CurrentImageIndex >= ImageList.length - 1;
                 };
-                
+
                 // Function to navigate to a specific image by index
                 let NavigateTo = (index) => {
                     if (index < 0 || index >= ImageList.length) return;
@@ -5834,7 +5851,7 @@ int main()
                     UpdateNavButtons();
                     UpdateImageSize();
                 };
-                
+
                 // Function to open modal
                 let OpenImageModal = (imgElement) => {
                     let PreviewImages = [...document.querySelectorAll("img.xmoj-image-preview")];
@@ -5852,22 +5869,22 @@ int main()
                     UpdateNavButtons();
                     UpdateImageSize();
                 };
-                
+
                 // Function to close modal
                 let CloseImageModal = () => {
                     ImageModal.classList.remove("show");
                 };
-                
+
                 // Close button click
                 CloseButton.addEventListener("click", CloseImageModal);
-                
+
                 // Close when clicking outside the image
                 ImageModal.addEventListener("click", (e) => {
                     if (e.target === ImageModal || e.target === ModalContent) {
                         CloseImageModal();
                     }
                 });
-                
+
                 // Keyboard shortcuts
                 document.addEventListener("keydown", (e) => {
                     if (ImageModal.classList.contains("show")) {
@@ -5884,7 +5901,7 @@ int main()
                         }
                     }
                 });
-                
+
                 // Touch events: pan when zoomed, swipe to navigate when at zoom level 1
                 ModalContent.addEventListener("touchstart", (e) => {
                     if (e.touches.length !== 1) return;
@@ -5898,7 +5915,7 @@ int main()
                         IsTouchPanning = false;
                     }
                 }, { passive: true });
-                
+
                 ModalContent.addEventListener("touchmove", (e) => {
                     if (!IsTouchPanning || e.touches.length !== 1) return;
                     PanX = TouchPanStartPanX + (e.touches[0].clientX - TouchStartX);
@@ -5906,7 +5923,7 @@ int main()
                     UpdateImageSize();
                     e.preventDefault();
                 }, { passive: false });
-                
+
                 ModalContent.addEventListener("touchend", (e) => {
                     if (IsTouchPanning) {
                         IsTouchPanning = false;
@@ -5925,7 +5942,7 @@ int main()
                         }
                     }
                 }, { passive: true });
-                
+
                 // Mouse drag to pan when zoomed
                 ModalContent.addEventListener("mousedown", (e) => {
                     if (CurrentZoom <= 1) return;
@@ -5939,14 +5956,14 @@ int main()
                     ModalContent.style.cursor = "grabbing";
                     e.preventDefault();
                 });
-                
+
                 document.addEventListener("mousemove", (e) => {
                     if (!IsDragging) return;
                     PanX = DragStartPanX + (e.clientX - DragStartX);
                     PanY = DragStartPanY + (e.clientY - DragStartY);
                     UpdateImageSize();
                 });
-                
+
                 document.addEventListener("mouseup", () => {
                     if (IsDragging) {
                         IsDragging = false;
@@ -5955,7 +5972,7 @@ int main()
                         ModalContent.style.cursor = CursorStyle;
                     }
                 });
-                
+
                 // Mouse wheel to zoom in/out
                 ModalContent.addEventListener("wheel", (e) => {
                     e.preventDefault();
@@ -5963,36 +5980,36 @@ int main()
                     CurrentZoom = Math.max(MinZoom, Math.min(MaxZoom, CurrentZoom + ZoomDelta));
                     UpdateImageSize();
                 }, { passive: false });
-                
+
                 // Navigation button clicks
                 PrevBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
                     NavigateTo(CurrentImageIndex - 1);
                 });
-                
+
                 NextBtn.addEventListener("click", (e) => {
                     e.stopPropagation();
                     NavigateTo(CurrentImageIndex + 1);
                 });
-                
+
                 // Zoom controls
                 ZoomInBtn.addEventListener("click", () => {
                     CurrentZoom = Math.min(CurrentZoom + ZoomStep, MaxZoom);
                     UpdateImageSize();
                 });
-                
+
                 ZoomOutBtn.addEventListener("click", () => {
                     CurrentZoom = Math.max(CurrentZoom - ZoomStep, MinZoom);
                     UpdateImageSize();
                 });
-                
+
                 ResetZoomBtn.addEventListener("click", () => {
                     CurrentZoom = 1;
                     PanX = 0;
                     PanY = 0;
                     UpdateImageSize();
                 });
-                
+
                 // Save/Download image: fetch via GM_xmlhttpRequest to bypass CORS, then use blob URL for reliable download
                 SaveBtn.addEventListener("click", () => {
                     let src = ModalImage.src;
@@ -6023,7 +6040,7 @@ int main()
                         }
                     });
                 });
-                
+
                 // Apply to all images on the page
                 let ApplyEnlargerToImage = (img) => {
                     const effectiveSrc = img.currentSrc || img.src;
@@ -6047,10 +6064,10 @@ int main()
                 let ApplyEnlargerToImages = () => {
                     document.querySelectorAll("img").forEach(ApplyEnlargerToImage);
                 };
-                
+
                 // Apply to existing images
                 ApplyEnlargerToImages();
-                
+
                 // Apply to dynamically added images
                 let Observer = new MutationObserver((mutations) => {
                     mutations.forEach((mutation) => {
@@ -6064,12 +6081,12 @@ int main()
                         });
                     });
                 });
-                
+
                 Observer.observe(document.body, {
                     childList: true,
                     subtree: true
                 });
-                
+
             } catch (e) {
                 console.error(e);
                 if (UtilityEnabled("DebugMode")) {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5590,26 +5590,6 @@ int main()
                         transition: opacity 0.2s ease;
                     }
                     
-                    .xmoj-image-preview::after {
-                        content: "点击放大";
-                        position: absolute;
-                        background-color: rgba(0, 0, 0, 0.7);
-                        color: white;
-                        padding: 5px 10px;
-                        border-radius: 3px;
-                        font-size: 12px;
-                        white-space: nowrap;
-                        pointer-events: none;
-                        opacity: 0;
-                        transition: opacity 0.2s ease;
-                        top: 50%;
-                        left: 50%;
-                        transform: translate(-50%, -50%);
-                    }
-                    
-                    .xmoj-image-preview:hover::after {
-                        opacity: 1;
-                    }
                     
                     .xmoj-image-modal {
                         display: none;
@@ -5691,8 +5671,11 @@ int main()
                 ImageModal.className = "xmoj-image-modal";
                 ImageModal.id = "xmoj-image-modal";
                 
-                let CloseButton = document.createElement("span");
+                let CloseButton = document.createElement("button");
                 CloseButton.className = "xmoj-image-modal-close";
+                CloseButton.type = "button";
+                CloseButton.setAttribute("aria-label", "关闭图片");
+                CloseButton.title = "关闭图片";
                 CloseButton.innerHTML = "&times;";
                 ImageModal.appendChild(CloseButton);
                 
@@ -5804,23 +5787,24 @@ int main()
                 });
                 
                 // Apply to all images on the page
+                let ApplyEnlargerToImage = (img) => {
+                    if (!img.classList.contains("xmoj-image-preview") && 
+                        !img.closest(".xmoj-image-modal") &&
+                        img.src && 
+                        !img.src.includes("gravatar") &&
+                        !img.src.includes("cravatar")) {
+                        
+                        img.classList.add("xmoj-image-preview");
+                        img.title = "点击放大";
+                        img.addEventListener("click", (e) => {
+                            e.stopPropagation();
+                            OpenImageModal(img.currentSrc || img.src);
+                        });
+                    }
+                };
+
                 let ApplyEnlargerToImages = () => {
-                    let Images = document.querySelectorAll("img");
-                    Images.forEach((img) => {
-                        if (!img.classList.contains("xmoj-image-preview") && 
-                            !img.parentElement.classList.contains("xmoj-image-modal") &&
-                            img.src && 
-                            !img.src.includes("gravatar") &&
-                            !img.src.includes("cravatar")) {
-                            
-                            img.classList.add("xmoj-image-preview");
-                            img.style.position = "relative";
-                            img.addEventListener("click", (e) => {
-                                e.stopPropagation();
-                                OpenImageModal(img.src);
-                            });
-                        }
-                    });
+                    document.querySelectorAll("img").forEach(ApplyEnlargerToImage);
                 };
                 
                 // Apply to existing images
@@ -5828,7 +5812,16 @@ int main()
                 
                 // Apply to dynamically added images
                 let Observer = new MutationObserver((mutations) => {
-                    ApplyEnlargerToImages();
+                    mutations.forEach((mutation) => {
+                        mutation.addedNodes.forEach((node) => {
+                            if (node.nodeType !== Node.ELEMENT_NODE) return;
+                            if (node.tagName === "IMG") {
+                                ApplyEnlargerToImage(node);
+                            } else {
+                                node.querySelectorAll("img").forEach(ApplyEnlargerToImage);
+                            }
+                        });
+                    });
                 });
                 
                 Observer.observe(document.body, {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.4
+// @version      3.3.5
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen
@@ -2277,6 +2277,11 @@ async function main() {
                         localStorage.setItem("UserScript-Problem-" + Temp[i].children[1].innerText + "-Name", Temp[i].children[2].innerText);
                     }
                 } else if (location.pathname == "/problem.php") {
+                    let transZhEn = document.getElementById("lang_cn_to_en");
+                    let transEnZh = document.getElementById("lang_en_to_cn");
+                    if (transZhEn !== null) await transZhEn.remove();
+                    if (transEnZh !== null) await transEnZh.remove();
+
                     await RenderMathJax();
                     if (SearchParams.get("cid") != null && UtilityEnabled("ProblemSwitcher")) {
                         let pid = localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-Problem-" + SearchParams.get("pid") + "-PID");

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2279,8 +2279,8 @@ async function main() {
                 } else if (location.pathname == "/problem.php") {
                     let transZhEn = document.getElementById("lang_cn_to_en");
                     let transEnZh = document.getElementById("lang_en_to_cn");
-                    if (transZhEn !== null) await transZhEn.remove();
-                    if (transEnZh !== null) await transEnZh.remove();
+                    if (transZhEn !== null) transZhEn.remove();
+                    if (transEnZh !== null) transEnZh.remove();
 
                     await RenderMathJax();
                     if (SearchParams.get("cid") != null && UtilityEnabled("ProblemSwitcher")) {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.3
+// @version      3.3.4
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5800,7 +5800,9 @@ int main()
                         !effectiveSrc.includes("cravatar")) {
 
                         img.classList.add("xmoj-image-preview");
-                        img.title = "点击放大";
+                        if (!img.title) {
+                            img.title = "点击放大";
+                        }
                         img.addEventListener("click", (e) => {
                             e.stopPropagation();
                             OpenImageModal(effectiveSrc);

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.2
+// @version      3.3.3
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5791,7 +5791,9 @@ int main()
                 let UpdateImageSize = () => {
                     ModalImage.style.transform = `translate(${PanX}px, ${PanY}px) scale(${CurrentZoom})`;
                     ModalImage.style.transition = IsDragging ? "none" : "transform 0.2s ease";
-                    ModalImage.style.cursor = CurrentZoom > 1 ? "grab" : "";
+                    let CursorStyle = CurrentZoom > 1 ? "grab" : "";
+                    ModalImage.style.cursor = CursorStyle;
+                    ModalContent.style.cursor = CursorStyle;
                 };
                 
                 // Function to update prev/next button state
@@ -5907,14 +5909,16 @@ int main()
                 }, { passive: true });
                 
                 // Mouse drag to pan when zoomed
-                ModalImage.addEventListener("mousedown", (e) => {
+                ModalContent.addEventListener("mousedown", (e) => {
                     if (CurrentZoom <= 1) return;
+                    if (e.target.tagName.toUpperCase() === "BUTTON") return;
                     IsDragging = true;
                     DragStartX = e.clientX;
                     DragStartY = e.clientY;
                     DragStartPanX = PanX;
                     DragStartPanY = PanY;
                     ModalImage.style.cursor = "grabbing";
+                    ModalContent.style.cursor = "grabbing";
                     e.preventDefault();
                 });
                 
@@ -5928,9 +5932,19 @@ int main()
                 document.addEventListener("mouseup", () => {
                     if (IsDragging) {
                         IsDragging = false;
-                        ModalImage.style.cursor = CurrentZoom > 1 ? "grab" : "";
+                        let CursorStyle = CurrentZoom > 1 ? "grab" : "";
+                        ModalImage.style.cursor = CursorStyle;
+                        ModalContent.style.cursor = CursorStyle;
                     }
                 });
+                
+                // Mouse wheel to zoom in/out
+                ModalContent.addEventListener("wheel", (e) => {
+                    e.preventDefault();
+                    let ZoomDelta = e.deltaY > 0 ? -ZoomStep : ZoomStep;
+                    CurrentZoom = Math.max(MinZoom, Math.min(MaxZoom, CurrentZoom + ZoomDelta));
+                    UpdateImageSize();
+                }, { passive: false });
                 
                 // Navigation button clicks
                 PrevBtn.addEventListener("click", (e) => {
@@ -5961,34 +5975,35 @@ int main()
                     UpdateImageSize();
                 });
                 
-                // Save/Download image using fetch to trigger actual download instead of redirecting
-                SaveBtn.addEventListener("click", async () => {
+                // Save/Download image: fetch via GM_xmlhttpRequest to bypass CORS, then use blob URL for reliable download
+                SaveBtn.addEventListener("click", () => {
                     let src = ModalImage.src;
                     let urlPath = src.split("?")[0];
                     let filename = urlPath.split("/").pop() || "image.png";
-                    try {
-                        let response = await fetch(src);
-                        if (!response.ok) throw new Error("Failed to fetch image");
-                        let blob = await response.blob();
-                        saveAs(blob, filename);
-                    } catch (e) {
-                        GM_xmlhttpRequest({
-                            method: "GET",
-                            url: src,
-                            responseType: "blob",
-                            onload: (resp) => {
-                                saveAs(resp.response, filename);
-                            },
-                            onerror: () => {
-                                let Link = document.createElement("a");
-                                Link.href = src;
-                                Link.download = filename;
-                                document.body.appendChild(Link);
-                                Link.click();
-                                document.body.removeChild(Link);
-                            }
-                        });
-                    }
+                    GM_xmlhttpRequest({
+                        method: "GET",
+                        url: src,
+                        responseType: "blob",
+                        onload: (resp) => {
+                            let BlobUrl = URL.createObjectURL(resp.response);
+                            let Link = document.createElement("a");
+                            Link.href = BlobUrl;
+                            Link.download = filename;
+                            document.body.appendChild(Link);
+                            Link.click();
+                            document.body.removeChild(Link);
+                            setTimeout(() => URL.revokeObjectURL(BlobUrl), 100);
+                        },
+                        onerror: () => {
+                            let Link = document.createElement("a");
+                            Link.href = src;
+                            Link.download = filename;
+                            Link.target = "_blank";
+                            document.body.appendChild(Link);
+                            Link.click();
+                            document.body.removeChild(Link);
+                        }
+                    });
                 });
                 
                 // Apply to all images on the page

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2526,11 +2526,19 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
+                            var checkNum = function(str) {
+                                var patrn = /^[0-9]{1,20}$/;
+                                var ans = true;
+                                if (!patrn.exec(str)) ans = false;
+                                return ans;
+                            }
+
                             const params = new URL(location.href).searchParams;
-                            let nonDigitPattern = /D/;
-                            let CurrentProblemId = isNaN(params.get("problem_id")) ? "" : params.get("problem_id");
-                            let CurrentLanguage = isNaN(params.get("language")) || params.get("language") < -1 || params.get("language") > 2 ? "-1" : params.get("language");
-                            let CurrentJresult = isNaN(params.get("jresult")) || params.get("jresult") < -1 || params.get("jresult") > 11 ? "-1" : params.get("jresult");
+                            let CurrentProblemId = checkNum(params.get("problem_id")) ? Number(params.get("problem_id")) : "";
+                            let CurrentLanguageParam = params.get("language");
+                            let CurrentLanguage = checkNum(CurrentLanguageParam) && -1 <= CurrentLanguageParam && CurrentLanguageParam <= 2 ? Number(CurrentLanguageParam) : "-1";
+                            let CurrentJresultParam = params.get("jresult");
+                            let CurrentJresult = checkNum(CurrentJresultParam) && -1 <= CurrentJresultParam && CurrentJresultParam <= 11 ? Number(CurrentJresultParam) : "-1";
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5613,6 +5613,7 @@ int main()
                         align-items: center;
                         justify-content: center;
                         overflow: auto;
+                        position: relative;
                     }
                     
                     .xmoj-image-modal-image {
@@ -5662,10 +5663,45 @@ int main()
                         font-weight: bold;
                         cursor: pointer;
                         transition: color 0.2s ease;
+                        z-index: 1;
                     }
                     
                     .xmoj-image-modal-close:hover {
                         color: #ccc;
+                    }
+                    
+                    .xmoj-image-modal-nav {
+                        position: absolute;
+                        top: 50%;
+                        transform: translateY(-50%);
+                        background: rgba(0, 0, 0, 0.5);
+                        color: white;
+                        border: none;
+                        padding: 20px 12px;
+                        cursor: pointer;
+                        font-size: 28px;
+                        transition: background-color 0.2s ease;
+                        user-select: none;
+                        -webkit-user-select: none;
+                    }
+                    
+                    .xmoj-image-modal-nav:hover {
+                        background: rgba(0, 0, 0, 0.8);
+                    }
+                    
+                    .xmoj-image-modal-nav:disabled {
+                        opacity: 0.3;
+                        cursor: default;
+                    }
+                    
+                    .xmoj-image-modal-nav-prev {
+                        left: 0;
+                        border-radius: 0 4px 4px 0;
+                    }
+                    
+                    .xmoj-image-modal-nav-next {
+                        right: 0;
+                        border-radius: 4px 0 0 4px;
                     }
                 `;
                 document.head.appendChild(EnlargerStyle);
@@ -5685,6 +5721,21 @@ int main()
                 
                 let ModalContent = document.createElement("div");
                 ModalContent.className = "xmoj-image-modal-content";
+                
+                let PrevBtn = document.createElement("button");
+                PrevBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-prev";
+                PrevBtn.type = "button";
+                PrevBtn.setAttribute("aria-label", "上一张");
+                PrevBtn.innerHTML = "&#10094;";
+                ModalContent.appendChild(PrevBtn);
+                
+                let NextBtn = document.createElement("button");
+                NextBtn.className = "xmoj-image-modal-nav xmoj-image-modal-nav-next";
+                NextBtn.type = "button";
+                NextBtn.setAttribute("aria-label", "下一张");
+                NextBtn.innerHTML = "&#10095;";
+                ModalContent.appendChild(NextBtn);
+                
                 let ModalImage = document.createElement("img");
                 ModalImage.className = "xmoj-image-modal-image";
                 ModalContent.appendChild(ModalImage);
@@ -5716,11 +5767,15 @@ int main()
                 ImageModal.appendChild(Toolbar);
                 document.body.appendChild(ImageModal);
                 
-                // Zoom level state
+                // Zoom level and navigation state
                 let CurrentZoom = 1;
                 const ZoomStep = 0.1;
                 const MinZoom = 0.1;
                 const MaxZoom = 5;
+                let ImageList = [];
+                let CurrentImageIndex = -1;
+                let TouchStartX = 0;
+                let TouchStartY = 0;
                 
                 // Function to update image size
                 let UpdateImageSize = () => {
@@ -5728,11 +5783,38 @@ int main()
                     ModalImage.style.transition = "transform 0.2s ease";
                 };
                 
-                // Function to open modal
-                let OpenImageModal = (imgSrc) => {
+                // Function to update prev/next button state
+                let UpdateNavButtons = () => {
+                    let HasMultiple = ImageList.length > 1;
+                    PrevBtn.style.display = HasMultiple ? "" : "none";
+                    NextBtn.style.display = HasMultiple ? "" : "none";
+                    PrevBtn.disabled = CurrentImageIndex <= 0;
+                    NextBtn.disabled = CurrentImageIndex >= ImageList.length - 1;
+                };
+                
+                // Function to navigate to a specific image by index
+                let NavigateTo = (index) => {
+                    if (index < 0 || index >= ImageList.length) return;
+                    CurrentImageIndex = index;
                     CurrentZoom = 1;
-                    ModalImage.src = imgSrc;
+                    ModalImage.src = ImageList[CurrentImageIndex];
+                    UpdateNavButtons();
+                    UpdateImageSize();
+                };
+                
+                // Function to open modal
+                let OpenImageModal = (imgElement) => {
+                    let PreviewImages = [...document.querySelectorAll("img.xmoj-image-preview")];
+                    ImageList = PreviewImages.map(img => img.currentSrc || img.src).filter(src => src);
+                    CurrentImageIndex = PreviewImages.indexOf(imgElement);
+                    if (CurrentImageIndex === -1) {
+                        ImageList = [(imgElement.currentSrc || imgElement.src)];
+                        CurrentImageIndex = 0;
+                    }
+                    CurrentZoom = 1;
+                    ModalImage.src = ImageList[CurrentImageIndex];
                     ImageModal.classList.add("show");
+                    UpdateNavButtons();
                     UpdateImageSize();
                 };
                 
@@ -5760,8 +5842,44 @@ int main()
                             ZoomInBtn.click();
                         } else if (e.key === "-") {
                             ZoomOutBtn.click();
+                        } else if (e.key === "ArrowLeft") {
+                            NavigateTo(CurrentImageIndex - 1);
+                        } else if (e.key === "ArrowRight") {
+                            NavigateTo(CurrentImageIndex + 1);
                         }
                     }
+                });
+                
+                // Touch swipe for image navigation
+                ModalContent.addEventListener("touchstart", (e) => {
+                    TouchStartX = e.changedTouches[0].screenX;
+                    TouchStartY = e.changedTouches[0].screenY;
+                }, { passive: true });
+                
+                ModalContent.addEventListener("touchend", (e) => {
+                    let TouchEndX = e.changedTouches[0].screenX;
+                    let TouchEndY = e.changedTouches[0].screenY;
+                    let DeltaX = TouchEndX - TouchStartX;
+                    let DeltaY = TouchEndY - TouchStartY;
+                    const SwipeThreshold = 50;
+                    if (Math.abs(DeltaX) > SwipeThreshold && Math.abs(DeltaX) > Math.abs(DeltaY)) {
+                        if (DeltaX < 0) {
+                            NavigateTo(CurrentImageIndex + 1);
+                        } else {
+                            NavigateTo(CurrentImageIndex - 1);
+                        }
+                    }
+                }, { passive: true });
+                
+                // Navigation button clicks
+                PrevBtn.addEventListener("click", (e) => {
+                    e.stopPropagation();
+                    NavigateTo(CurrentImageIndex - 1);
+                });
+                
+                NextBtn.addEventListener("click", (e) => {
+                    e.stopPropagation();
+                    NavigateTo(CurrentImageIndex + 1);
                 });
                 
                 // Zoom controls
@@ -5780,14 +5898,32 @@ int main()
                     UpdateImageSize();
                 });
                 
-                // Save/Download image
-                SaveBtn.addEventListener("click", () => {
-                    let Link = document.createElement("a");
-                    Link.href = ModalImage.src;
-                    Link.download = ModalImage.src.split("/").pop() || "image.png";
-                    document.body.appendChild(Link);
-                    Link.click();
-                    document.body.removeChild(Link);
+                // Save/Download image using fetch to trigger actual download instead of redirecting
+                SaveBtn.addEventListener("click", async () => {
+                    let src = ModalImage.src;
+                    let filename = src.split("/").pop().split("?")[0] || "image.png";
+                    try {
+                        let response = await fetch(src);
+                        let blob = await response.blob();
+                        saveAs(blob, filename);
+                    } catch (e) {
+                        GM_xmlhttpRequest({
+                            method: "GET",
+                            url: src,
+                            responseType: "blob",
+                            onload: (resp) => {
+                                saveAs(resp.response, filename);
+                            },
+                            onerror: () => {
+                                let Link = document.createElement("a");
+                                Link.href = src;
+                                Link.download = filename;
+                                document.body.appendChild(Link);
+                                Link.click();
+                                document.body.removeChild(Link);
+                            }
+                        });
+                    }
                 });
                 
                 // Apply to all images on the page
@@ -5805,7 +5941,7 @@ int main()
                         }
                         img.addEventListener("click", (e) => {
                             e.stopPropagation();
-                            OpenImageModal(effectiveSrc);
+                            OpenImageModal(img);
                         });
                     }
                 };

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5654,6 +5654,10 @@ int main()
                         top: 20px;
                         right: 30px;
                         color: white;
+                        background: none;
+                        border: none;
+                        padding: 0;
+                        line-height: 1;
                         font-size: 40px;
                         font-weight: bold;
                         cursor: pointer;

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -5612,7 +5612,7 @@ int main()
                         display: flex;
                         align-items: center;
                         justify-content: center;
-                        overflow: auto;
+                        overflow: hidden;
                         position: relative;
                     }
                     
@@ -5774,13 +5774,24 @@ int main()
                 const MaxZoom = 5;
                 let ImageList = [];
                 let CurrentImageIndex = -1;
+                let PanX = 0;
+                let PanY = 0;
+                let IsDragging = false;
+                let DragStartX = 0;
+                let DragStartY = 0;
+                let DragStartPanX = 0;
+                let DragStartPanY = 0;
+                let IsTouchPanning = false;
                 let TouchStartX = 0;
                 let TouchStartY = 0;
+                let TouchPanStartPanX = 0;
+                let TouchPanStartPanY = 0;
                 
-                // Function to update image size
+                // Function to update image transform (zoom + pan)
                 let UpdateImageSize = () => {
-                    ModalImage.style.transform = `scale(${CurrentZoom})`;
-                    ModalImage.style.transition = "transform 0.2s ease";
+                    ModalImage.style.transform = `translate(${PanX}px, ${PanY}px) scale(${CurrentZoom})`;
+                    ModalImage.style.transition = IsDragging ? "none" : "transform 0.2s ease";
+                    ModalImage.style.cursor = CurrentZoom > 1 ? "grab" : "";
                 };
                 
                 // Function to update prev/next button state
@@ -5797,6 +5808,8 @@ int main()
                     if (index < 0 || index >= ImageList.length) return;
                     CurrentImageIndex = index;
                     CurrentZoom = 1;
+                    PanX = 0;
+                    PanY = 0;
                     ModalImage.src = ImageList[CurrentImageIndex];
                     UpdateNavButtons();
                     UpdateImageSize();
@@ -5812,6 +5825,8 @@ int main()
                         CurrentImageIndex = 0;
                     }
                     CurrentZoom = 1;
+                    PanX = 0;
+                    PanY = 0;
                     ModalImage.src = ImageList[CurrentImageIndex];
                     ImageModal.classList.add("show");
                     UpdateNavButtons();
@@ -5850,15 +5865,35 @@ int main()
                     }
                 });
                 
-                // Touch swipe for image navigation
+                // Touch events: pan when zoomed, swipe to navigate when at zoom level 1
                 ModalContent.addEventListener("touchstart", (e) => {
-                    TouchStartX = e.changedTouches[0].screenX;
-                    TouchStartY = e.changedTouches[0].screenY;
+                    if (e.touches.length !== 1) return;
+                    TouchStartX = e.touches[0].clientX;
+                    TouchStartY = e.touches[0].clientY;
+                    if (CurrentZoom > 1) {
+                        IsTouchPanning = true;
+                        TouchPanStartPanX = PanX;
+                        TouchPanStartPanY = PanY;
+                    } else {
+                        IsTouchPanning = false;
+                    }
                 }, { passive: true });
                 
+                ModalContent.addEventListener("touchmove", (e) => {
+                    if (!IsTouchPanning || e.touches.length !== 1) return;
+                    PanX = TouchPanStartPanX + (e.touches[0].clientX - TouchStartX);
+                    PanY = TouchPanStartPanY + (e.touches[0].clientY - TouchStartY);
+                    UpdateImageSize();
+                    e.preventDefault();
+                }, { passive: false });
+                
                 ModalContent.addEventListener("touchend", (e) => {
-                    let TouchEndX = e.changedTouches[0].screenX;
-                    let TouchEndY = e.changedTouches[0].screenY;
+                    if (IsTouchPanning) {
+                        IsTouchPanning = false;
+                        return;
+                    }
+                    let TouchEndX = e.changedTouches[0].clientX;
+                    let TouchEndY = e.changedTouches[0].clientY;
                     let DeltaX = TouchEndX - TouchStartX;
                     let DeltaY = TouchEndY - TouchStartY;
                     const SwipeThreshold = 50;
@@ -5870,6 +5905,32 @@ int main()
                         }
                     }
                 }, { passive: true });
+                
+                // Mouse drag to pan when zoomed
+                ModalImage.addEventListener("mousedown", (e) => {
+                    if (CurrentZoom <= 1) return;
+                    IsDragging = true;
+                    DragStartX = e.clientX;
+                    DragStartY = e.clientY;
+                    DragStartPanX = PanX;
+                    DragStartPanY = PanY;
+                    ModalImage.style.cursor = "grabbing";
+                    e.preventDefault();
+                });
+                
+                document.addEventListener("mousemove", (e) => {
+                    if (!IsDragging) return;
+                    PanX = DragStartPanX + (e.clientX - DragStartX);
+                    PanY = DragStartPanY + (e.clientY - DragStartY);
+                    UpdateImageSize();
+                });
+                
+                document.addEventListener("mouseup", () => {
+                    if (IsDragging) {
+                        IsDragging = false;
+                        ModalImage.style.cursor = CurrentZoom > 1 ? "grab" : "";
+                    }
+                });
                 
                 // Navigation button clicks
                 PrevBtn.addEventListener("click", (e) => {
@@ -5895,15 +5956,19 @@ int main()
                 
                 ResetZoomBtn.addEventListener("click", () => {
                     CurrentZoom = 1;
+                    PanX = 0;
+                    PanY = 0;
                     UpdateImageSize();
                 });
                 
                 // Save/Download image using fetch to trigger actual download instead of redirecting
                 SaveBtn.addEventListener("click", async () => {
                     let src = ModalImage.src;
-                    let filename = src.split("/").pop().split("?")[0] || "image.png";
+                    let urlPath = src.split("?")[0];
+                    let filename = urlPath.split("/").pop() || "image.png";
                     try {
                         let response = await fetch(src);
+                        if (!response.ok) throw new Error("Failed to fetch image");
                         let blob = await response.blob();
                         saveAs(blob, filename);
                     } catch (e) {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -2121,6 +2121,8 @@ async function main() {
                         }, {"ID": "CompareSource", "Type": "A", "Name": "比较代码"}, {
                             "ID": "BBSPopup", "Type": "A", "Name": "讨论提醒"
                         }, {"ID": "MessagePopup", "Type": "A", "Name": "短消息提醒"}, {
+                            "ID": "ImageEnlarger", "Type": "A", "Name": "图片放大功能"
+                        }, {
                             "ID": "DebugMode", "Type": "A", "Name": "调试模式（仅供开发者使用）"
                         }, {
                             "ID": "SuperDebug", "Type": "A", "Name": "本地调试模式（仅供开发者使用) (未经授权的擅自开启将导致大部分功能不可用！)"
@@ -5569,6 +5571,275 @@ int main()
                             }
                         }
                     }
+                }
+            }
+        }
+
+        // Image Enlargement Feature
+        if (UtilityEnabled("ImageEnlarger")) {
+            try {
+                // Add CSS styles for the enlarger
+                let EnlargerStyle = document.createElement("style");
+                EnlargerStyle.textContent = `
+                    .xmoj-image-preview {
+                        cursor: pointer;
+                    }
+                    
+                    .xmoj-image-preview:hover {
+                        opacity: 0.8;
+                        transition: opacity 0.2s ease;
+                    }
+                    
+                    .xmoj-image-preview::after {
+                        content: "点击放大";
+                        position: absolute;
+                        background-color: rgba(0, 0, 0, 0.7);
+                        color: white;
+                        padding: 5px 10px;
+                        border-radius: 3px;
+                        font-size: 12px;
+                        white-space: nowrap;
+                        pointer-events: none;
+                        opacity: 0;
+                        transition: opacity 0.2s ease;
+                        top: 50%;
+                        left: 50%;
+                        transform: translate(-50%, -50%);
+                    }
+                    
+                    .xmoj-image-preview:hover::after {
+                        opacity: 1;
+                    }
+                    
+                    .xmoj-image-modal {
+                        display: none;
+                        position: fixed;
+                        z-index: 2000;
+                        left: 0;
+                        top: 0;
+                        width: 100%;
+                        height: 100%;
+                        background-color: rgba(0, 0, 0, 0.9);
+                    }
+                    
+                    .xmoj-image-modal.show {
+                        display: flex;
+                        flex-direction: column;
+                    }
+                    
+                    .xmoj-image-modal-content {
+                        flex: 1;
+                        display: flex;
+                        align-items: center;
+                        justify-content: center;
+                        overflow: auto;
+                    }
+                    
+                    .xmoj-image-modal-image {
+                        max-width: 100%;
+                        max-height: 100%;
+                        object-fit: contain;
+                    }
+                    
+                    .xmoj-image-modal-toolbar {
+                        display: flex;
+                        justify-content: center;
+                        gap: 10px;
+                        padding: 15px;
+                        background-color: rgba(0, 0, 0, 0.5);
+                        flex-wrap: wrap;
+                    }
+                    
+                    .xmoj-image-modal-toolbar button {
+                        padding: 8px 16px;
+                        background-color: #0d6efd;
+                        color: white;
+                        border: none;
+                        border-radius: 4px;
+                        cursor: pointer;
+                        font-size: 14px;
+                        transition: background-color 0.2s ease;
+                    }
+                    
+                    .xmoj-image-modal-toolbar button:hover {
+                        background-color: #0b5ed7;
+                    }
+                    
+                    .xmoj-image-modal-toolbar button:active {
+                        background-color: #0a58ca;
+                    }
+                    
+                    .xmoj-image-modal-close {
+                        position: absolute;
+                        top: 20px;
+                        right: 30px;
+                        color: white;
+                        font-size: 40px;
+                        font-weight: bold;
+                        cursor: pointer;
+                        transition: color 0.2s ease;
+                    }
+                    
+                    .xmoj-image-modal-close:hover {
+                        color: #ccc;
+                    }
+                `;
+                document.head.appendChild(EnlargerStyle);
+                
+                // Create modal element
+                let ImageModal = document.createElement("div");
+                ImageModal.className = "xmoj-image-modal";
+                ImageModal.id = "xmoj-image-modal";
+                
+                let CloseButton = document.createElement("span");
+                CloseButton.className = "xmoj-image-modal-close";
+                CloseButton.innerHTML = "&times;";
+                ImageModal.appendChild(CloseButton);
+                
+                let ModalContent = document.createElement("div");
+                ModalContent.className = "xmoj-image-modal-content";
+                let ModalImage = document.createElement("img");
+                ModalImage.className = "xmoj-image-modal-image";
+                ModalContent.appendChild(ModalImage);
+                ImageModal.appendChild(ModalContent);
+                
+                let Toolbar = document.createElement("div");
+                Toolbar.className = "xmoj-image-modal-toolbar";
+                
+                let ZoomInBtn = document.createElement("button");
+                ZoomInBtn.innerHTML = "放大 (+)";
+                ZoomInBtn.type = "button";
+                Toolbar.appendChild(ZoomInBtn);
+                
+                let ZoomOutBtn = document.createElement("button");
+                ZoomOutBtn.innerHTML = "缩小 (-)";
+                ZoomOutBtn.type = "button";
+                Toolbar.appendChild(ZoomOutBtn);
+                
+                let ResetZoomBtn = document.createElement("button");
+                ResetZoomBtn.innerHTML = "重置大小";
+                ResetZoomBtn.type = "button";
+                Toolbar.appendChild(ResetZoomBtn);
+                
+                let SaveBtn = document.createElement("button");
+                SaveBtn.innerHTML = "保存图片";
+                SaveBtn.type = "button";
+                Toolbar.appendChild(SaveBtn);
+                
+                ImageModal.appendChild(Toolbar);
+                document.body.appendChild(ImageModal);
+                
+                // Zoom level state
+                let CurrentZoom = 1;
+                const ZoomStep = 0.1;
+                const MinZoom = 0.1;
+                const MaxZoom = 5;
+                
+                // Function to update image size
+                let UpdateImageSize = () => {
+                    ModalImage.style.transform = `scale(${CurrentZoom})`;
+                    ModalImage.style.transition = "transform 0.2s ease";
+                };
+                
+                // Function to open modal
+                let OpenImageModal = (imgSrc) => {
+                    CurrentZoom = 1;
+                    ModalImage.src = imgSrc;
+                    ImageModal.classList.add("show");
+                    UpdateImageSize();
+                };
+                
+                // Function to close modal
+                let CloseImageModal = () => {
+                    ImageModal.classList.remove("show");
+                };
+                
+                // Close button click
+                CloseButton.addEventListener("click", CloseImageModal);
+                
+                // Close when clicking outside the image
+                ImageModal.addEventListener("click", (e) => {
+                    if (e.target === ImageModal || e.target === ModalContent) {
+                        CloseImageModal();
+                    }
+                });
+                
+                // Keyboard shortcuts
+                document.addEventListener("keydown", (e) => {
+                    if (ImageModal.classList.contains("show")) {
+                        if (e.key === "Escape") {
+                            CloseImageModal();
+                        } else if (e.key === "+") {
+                            ZoomInBtn.click();
+                        } else if (e.key === "-") {
+                            ZoomOutBtn.click();
+                        }
+                    }
+                });
+                
+                // Zoom controls
+                ZoomInBtn.addEventListener("click", () => {
+                    CurrentZoom = Math.min(CurrentZoom + ZoomStep, MaxZoom);
+                    UpdateImageSize();
+                });
+                
+                ZoomOutBtn.addEventListener("click", () => {
+                    CurrentZoom = Math.max(CurrentZoom - ZoomStep, MinZoom);
+                    UpdateImageSize();
+                });
+                
+                ResetZoomBtn.addEventListener("click", () => {
+                    CurrentZoom = 1;
+                    UpdateImageSize();
+                });
+                
+                // Save/Download image
+                SaveBtn.addEventListener("click", () => {
+                    let Link = document.createElement("a");
+                    Link.href = ModalImage.src;
+                    Link.download = ModalImage.src.split("/").pop() || "image.png";
+                    document.body.appendChild(Link);
+                    Link.click();
+                    document.body.removeChild(Link);
+                });
+                
+                // Apply to all images on the page
+                let ApplyEnlargerToImages = () => {
+                    let Images = document.querySelectorAll("img");
+                    Images.forEach((img) => {
+                        if (!img.classList.contains("xmoj-image-preview") && 
+                            !img.parentElement.classList.contains("xmoj-image-modal") &&
+                            img.src && 
+                            !img.src.includes("gravatar") &&
+                            !img.src.includes("cravatar")) {
+                            
+                            img.classList.add("xmoj-image-preview");
+                            img.style.position = "relative";
+                            img.addEventListener("click", (e) => {
+                                e.stopPropagation();
+                                OpenImageModal(img.src);
+                            });
+                        }
+                    });
+                };
+                
+                // Apply to existing images
+                ApplyEnlargerToImages();
+                
+                // Apply to dynamically added images
+                let Observer = new MutationObserver((mutations) => {
+                    ApplyEnlargerToImages();
+                });
+                
+                Observer.observe(document.body, {
+                    childList: true,
+                    subtree: true
+                });
+                
+            } catch (e) {
+                console.error(e);
+                if (UtilityEnabled("DebugMode")) {
+                    SmartAlert("XMOJ-Script internal error!\n\n" + e + "\n\n" + "If you see this message, please report it to the developer.\nDon't forget to include console logs and a way to reproduce the error!\n\nDon't want to see this message? Disable DebugMode.");
                 }
             }
         }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.1
+// @version      3.3.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen
@@ -532,6 +532,29 @@ let RequestAPI = (Action, Data, CallBack) => {
         }
     }
 };
+
+unsafeWindow.GetContestProblemList = async function(RefreshList) {
+    try {
+        const contestReq = await fetch("https://www.xmoj.tech/contest.php?cid=" + SearchParams.get("cid"));
+        const res = await contestReq.text();
+        if (contestReq.status === 200 && res.indexOf("比赛尚未开始或私有，不能查看题目。") === -1) {
+            const parser = new DOMParser();
+            const dom = parser.parseFromString(res, "text/html");
+            const rows = (dom.querySelector("#problemset > tbody")).rows;
+            let problemList = [];
+            for (let i = 0; i < rows.length; i++) {
+                problemList.push({
+                    "title": rows[i].children[2].innerText,
+                    "url": rows[i].children[2].children[0].href
+                });
+            }
+            localStorage.setItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList", JSON.stringify(problemList));
+            if (RefreshList) location.reload();
+        }
+    } catch (e) {
+        console.error(e);
+    }
+}
 
 // WebSocket Notification System
 let NotificationSocket = null;
@@ -1551,6 +1574,9 @@ async function main() {
                         display: none !important;
                     }
                 }
+                .refreshList {
+                    cursor: pointer;
+                }
 
                 /* Contain images */
                 img {
@@ -1616,6 +1642,11 @@ async function main() {
                     border: 1px solid var(--bs-secondary-bg);
                     border-top: none;
                     border-radius: 0 0 0.3rem 0.3rem;
+                }
+                .refreshList {
+                    cursor: pointer;
+                    color: #6c757d;
+                    text-decoration: none;
                 }`;
                 }
                 if (UtilityEnabled("AddAnimation")) {
@@ -2272,22 +2303,8 @@ async function main() {
                         }
                         let ContestProblemList = localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList");
                         if (ContestProblemList == null) {
-                            const contestReq = await fetch("https://www.xmoj.tech/contest.php?cid=" + SearchParams.get("cid"));
-                            const res = await contestReq.text();
-                            if (contestReq.status === 200 && res.indexOf("比赛尚未开始或私有，不能查看题目。") === -1) {
-                                const parser = new DOMParser();
-                                const dom = parser.parseFromString(res, "text/html");
-                                const rows = (dom.querySelector("#problemset > tbody")).rows;
-                                let problemList = [];
-                                for (let i = 0; i < rows.length; i++) {
-                                    problemList.push({
-                                        "title": rows[i].children[2].innerText,
-                                        "url": rows[i].children[2].children[0].href
-                                    });
-                                }
-                                localStorage.setItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList", JSON.stringify(problemList));
-                                ContestProblemList = JSON.stringify(problemList);
-                            }
+                            await unsafeWindow.GetContestProblemList(false);
+                            ContestProblemList = localStorage.getItem("UserScript-Contest-" + SearchParams.get("cid") + "-ProblemList");
                         }
 
                         let problemSwitcher = document.createElement("div");
@@ -2310,6 +2327,7 @@ async function main() {
                         problemSwitcher.style.flexDirection = "column";
 
                         let problemList = JSON.parse(ContestProblemList);
+                        problemSwitcher.innerHTML += `<a onclick="GetContestProblemList(true)" title="刷新列表" class="refreshList mb-2" style="text-align: center;" active>刷新</a>`;
                         for (let i = 0; i < problemList.length; i++) {
                             let buttonText = "";
                             if (i < 26) {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3043,13 +3043,15 @@ async function main() {
                             HeaderCells[2].innerText = "昵称";
                             HeaderCells[3].innerText = "AC数";
                             HeaderCells[4].innerText = "得分";
-                            for (let j = 0; j < HeaderCells.length; j++) {
-                                HeaderCells[j].removeAttribute("bgcolor");
-                                HeaderCells[j].style.setProperty("background-color", "black", "important");
-                                HeaderCells[j].style.setProperty("color", "white", "important");
-                                let Links = HeaderCells[j].querySelectorAll("a");
-                                for (let k = 0; k < Links.length; k++) {
-                                    Links[k].style.setProperty("color", "white", "important");
+                            if (UtilityEnabled("MonochromeUI")) {
+                                for (let j = 0; j < HeaderCells.length; j++) {
+                                    HeaderCells[j].removeAttribute("bgcolor");
+                                    HeaderCells[j].style.setProperty("background-color", "black", "important");
+                                    HeaderCells[j].style.setProperty("color", "white", "important");
+                                    let Links = HeaderCells[j].querySelectorAll("a");
+                                    for (let k = 0; k < Links.length; k++) {
+                                        Links[k].style.setProperty("color", "white", "important");
+                                    }
                                 }
                             }
                             let RefreshOIRank = async () => {
@@ -3062,7 +3064,9 @@ async function main() {
                                         TidyTable(ParsedDocument.getElementById("rank"));
                                         let Temp = ParsedDocument.getElementById("rank").rows;
                                         for (var i = 1; i < Temp.length; i++) {
-                                            Temp[i].style.backgroundColor = "";
+                                            if (UtilityEnabled("MonochromeUI")) {
+                                                Temp[i].style.backgroundColor = "";
+                                            }
                                             let MetalCell = Temp[i].cells[0];
                                             let Metal = document.createElement("span");
                                             Metal.innerText = MetalCell.innerText;
@@ -3072,9 +3076,11 @@ async function main() {
                                             GetUsernameHTML(Temp[i].cells[1], Temp[i].cells[1].innerText);
                                             Temp[i].cells[2].innerHTML = Temp[i].cells[2].innerText;
                                             Temp[i].cells[3].innerHTML = Temp[i].cells[3].innerText;
-                                            for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
-                                                Temp[i].cells[j].style.backgroundColor = "";
-                                                Temp[i].cells[j].style.color = "";
+                                            if (UtilityEnabled("MonochromeUI")) {
+                                                for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
+                                                    Temp[i].cells[j].style.backgroundColor = "";
+                                                    Temp[i].cells[j].style.color = "";
+                                                }
                                             }
                                             for (let j = 5; j < Temp[i].cells.length; j++) {
                                                 let InnerText = Temp[i].cells[j].innerText;
@@ -3144,13 +3150,15 @@ async function main() {
                         HeaderCells[2].innerText = "昵称";
                         HeaderCells[3].innerText = "AC数";
                         HeaderCells[4].innerText = "得分";
-                        for (let j = 0; j < HeaderCells.length; j++) {
-                            HeaderCells[j].removeAttribute("bgcolor");
-                            HeaderCells[j].style.setProperty("background-color", "black", "important");
-                            HeaderCells[j].style.setProperty("color", "white", "important");
-                            let Links = HeaderCells[j].querySelectorAll("a");
-                            for (let k = 0; k < Links.length; k++) {
-                                Links[k].style.setProperty("color", "white", "important");
+                        if (UtilityEnabled("MonochromeUI")) {
+                            for (let j = 0; j < HeaderCells.length; j++) {
+                                HeaderCells[j].removeAttribute("bgcolor");
+                                HeaderCells[j].style.setProperty("background-color", "black", "important");
+                                HeaderCells[j].style.setProperty("color", "white", "important");
+                                let Links = HeaderCells[j].querySelectorAll("a");
+                                for (let k = 0; k < Links.length; k++) {
+                                    Links[k].style.setProperty("color", "white", "important");
+                                }
                             }
                         }
                         let RefreshCorrectRank = async () => {
@@ -3163,7 +3171,9 @@ async function main() {
                                     TidyTable(ParsedDocument.getElementById("rank"));
                                     let Temp = ParsedDocument.getElementById("rank").rows;
                                     for (var i = 1; i < Temp.length; i++) {
-                                        Temp[i].style.backgroundColor = "";
+                                        if (UtilityEnabled("MonochromeUI")) {
+                                            Temp[i].style.backgroundColor = "";
+                                        }
                                         let MetalCell = Temp[i].cells[0];
                                         let Metal = document.createElement("span");
                                         Metal.innerText = MetalCell.innerText;
@@ -3173,9 +3183,11 @@ async function main() {
                                         GetUsernameHTML(Temp[i].cells[1], Temp[i].cells[1].innerText);
                                         Temp[i].cells[2].innerHTML = Temp[i].cells[2].innerText;
                                         Temp[i].cells[3].innerHTML = Temp[i].cells[3].innerText;
-                                        for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
-                                            Temp[i].cells[j].style.backgroundColor = "";
-                                            Temp[i].cells[j].style.color = "";
+                                        if (UtilityEnabled("MonochromeUI")) {
+                                            for (let j = 0; j < 5 && j < Temp[i].cells.length; j++) {
+                                                Temp[i].cells[j].style.backgroundColor = "";
+                                                Temp[i].cells[j].style.color = "";
+                                            }
                                         }
                                         for (let j = 5; j < Temp[i].cells.length; j++) {
                                             let InnerText = Temp[i].cells[j].innerText;

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.3.3
+// @version      3.3.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen
@@ -2526,23 +2526,16 @@ async function main() {
                         document.title = "提交状态";
                         document.querySelector("body > script:nth-child(5)").remove();
                         if (UtilityEnabled("NewBootstrap")) {
-                            const url = window.location.href;
-                            const paramsRegex = /[?&]([^=#]+)=([^&#]*)/g;
-                            let match;
-                            let CurrentProblemId, CurrentLanguage, CurrentJresult;
-                            while ((match = paramsRegex.exec(url)) !== null) {
-                                const [_, key, value] = match;
-                                if (key == 'problem_id') CurrentProblemId = value;
-                                if (key == 'language') CurrentLanguage = value;
-                                if (key == 'jresult') CurrentJresult = value;
-                            }
-                            console.log(CurrentProblemId + '\n' + CurrentLanguage + '\n' + CurrentJresult);
+                            const params = new URLSearchParams(window.location.search);
+                            const CurrentProblemId = params.get('problem_id');
+                            const CurrentLanguage = params.get('language');
+                            const CurrentJresult = params.get('jresult');
 
                             document.querySelector("#simform").outerHTML = `<form id="simform" class="justify-content-center form-inline row g-2" action="status.php" method="get" style="padding-bottom: 7px;">
                     <input class="form-control" type="text" size="4" name="user_id" value="${CurrentUsername} "style="display: none;">
                 <div class="col-md-1">
                     <label for="problem_id" class="form-label">题目编号</label>
-                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4" value="${CurrentProblemId}">
+                    <input type="text" class="form-control" id="problem_id" name="problem_id" size="4">
                 </div>
                 <div class="col-md-1">
                     <label for="language" class="form-label">语言</label>
@@ -2574,7 +2567,9 @@ async function main() {
                     <button type="submit" class="btn btn-primary">查找</button>
                 </div><div id="csrf"></div></form>`;
 
-                            var selectElement = document.getElementById('language');
+                            var selectElement = document.getElementById('problem_id');
+                            selectElement.value = CurrentProblemId;
+                            selectElement = document.getElementById('language');
                             selectElement.value = CurrentLanguage;
                             selectElement = document.getElementById('jresult');
                             selectElement.value = CurrentJresult;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
                         <a class="nav-link" href="#About">关于</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="messages.html">短消息 WebUI
+                        <a class="nav-link" href="messages.html">短消息在线看
                             <span class="badge bg-warning text-dark ms-1">Alpha</span>
                         </a>
                     </li>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6214673028530012"
      crossorigin="anonymous"></script>
     <meta name="viewport" content="width=device-width">
-    <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.2.3/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.2.3/js/bootstrap.min.js"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.min.js"></script>
     <title>小明的OJ增强脚本</title>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -47,6 +47,11 @@
                     <li class="nav-item">
                         <a class="nav-link" href="#About">关于</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="messages.html">短消息 WebUI
+                            <span class="badge bg-warning text-dark ms-1">Alpha</span>
+                        </a>
+                    </li>
                 </ul>
             </div>
         </div>
@@ -129,7 +134,7 @@
             <ul class="list-group">
                 <li class="list-group-item"><b>比赛ACM排名与下载功能</b>：允许用户查看比赛的ACM排名，并提供下载选项，方便离线查阅。</li>
                 <li class="list-group-item"><b>讨论区</b>：我们自行搭建了一个讨论服务，你可以在里面发表你的声音。</li>
-                <li class="list-group-item"><b>短消息</b>：我们自行搭建了一个短消息服务，你可以在这里和你最好的伙伴交流。</li>
+                <li class="list-group-item"><b>短消息</b>：我们自行搭建了一个短消息服务，你可以在这里和你最好的伙伴交流。iOS/iPadOS 等无法安装用户脚本的设备可使用 <a href="messages.html">短消息 WebUI</a>（Alpha）直接收发消息。</li>
                 <li class="list-group-item"><b>查看更多标程</b>：展示更多的标准程序代码，帮助用户更好地理解题目要求和正确解法。</li>
                 <li class="list-group-item"><b>获取别人的测试点数据</b>：允许用户获取其他人的测试点数据，用于分析问题和优化代码。</li>
                 <li class="list-group-item"><b>自动刷新比赛列表与排名</b>：使比赛列表和排名页面自动定时刷新，获取最新信息。</li>

--- a/messages.html
+++ b/messages.html
@@ -451,6 +451,54 @@ function userSpan(username) {
            escapeHtml(username) + '</button>';
 }
 
+function loadBadgesForContainer(container) {
+    // Group buttons by username in a single DOM pass
+    var byUsername = new Map();
+    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
+        var u = btn.dataset.username;
+        if (!u) return;
+        if (!byUsername.has(u)) byUsername.set(u, []);
+        byUsername.get(u).push(btn);
+    });
+    byUsername.forEach(function(btns, u) {
+        getUserBadge(u).then(function(badge) {
+            if (!badge || !badge.Content) return;
+            btns.forEach(function(b) {
+                // Avoid duplicates on re-render
+                if (b.nextElementSibling && b.nextElementSibling.classList.contains('user-badge')) return;
+                var span = document.createElement('span');
+                span.className = 'badge ms-1 user-badge';
+                span.style.backgroundColor = badge.BackgroundColor;
+                span.style.color = badge.Color;
+                span.textContent = badge.Content;
+                b.insertAdjacentElement('afterend', span);
+            });
+        }).catch(function() {});
+    });
+}
+
+async function getUserBadge(username) {
+    var BADGE_TTL = 1000 * 60 * 60 * 24; // 24 h, matching XMOJ.user.js
+    var prefix = 'UserScript-User-' + username + '-Badge-';
+    var lastUpdate = localStorage.getItem(prefix + 'LastUpdateTime');
+    if (lastUpdate && (Date.now() - parseInt(lastUpdate)) < BADGE_TTL) {
+        return {
+            BackgroundColor: localStorage.getItem(prefix + 'BackgroundColor') || '',
+            Color: localStorage.getItem(prefix + 'Color') || '',
+            Content: localStorage.getItem(prefix + 'Content') || ''
+        };
+    }
+    var result = await apiCall('GetBadge', { UserID: username });
+    var badge = (result && result.Success && result.Data)
+        ? result.Data
+        : { BackgroundColor: '', Color: '', Content: '' };
+    localStorage.setItem(prefix + 'BackgroundColor', badge.BackgroundColor || '');
+    localStorage.setItem(prefix + 'Color', badge.Color || '');
+    localStorage.setItem(prefix + 'Content', badge.Content || '');
+    localStorage.setItem(prefix + 'LastUpdateTime', String(Date.now()));
+    return badge;
+}
+
 async function showUserInfo(username) {
     var title = document.getElementById('user-info-modal-title');
     var body = document.getElementById('user-info-modal-body');
@@ -462,57 +510,68 @@ async function showUserInfo(username) {
     body.innerHTML = '<div class="text-center py-3"><span class="spinner-border spinner-border-sm me-2"></span>加载中…</div>';
     userInfoModalBS.show();
 
-    try {
-        var res = await fetch(profileUrl, {
-            referrer: XMOJ_BASE + '/',
-            credentials: 'include'
-        });
-        if (!res.ok) throw new Error('HTTP ' + res.status);
-        var html = await res.text();
+    var results = await Promise.allSettled([
+        fetch(profileUrl, { referrer: XMOJ_BASE + '/', credentials: 'include' })
+            .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); }),
+        getUserBadge(username)
+    ]);
 
-        if (html.indexOf('No such User!') !== -1) {
-            body.innerHTML = '<p class="text-body-secondary mb-0">用户不存在。</p>';
-            return;
-        }
-
-        var doc = new DOMParser().parseFromString(html, 'text/html');
-
-        var captionEl = doc.querySelector('#statics > caption');
-        var nickname = '';
-        if (captionEl) {
-            // Caption text format: "UserID--Nickname"
-            var parts = captionEl.textContent.trim().split('--');
-            if (parts.length > 1) nickname = parts[1].trim();
-        }
-
-        var submitEl = doc.querySelector('#statics > tbody > tr:nth-child(3) > td:nth-child(2)');
-        var acceptEl = doc.querySelector('#statics > tbody > tr:nth-child(4) > td:nth-child(2)');
-        var submitCount = submitEl ? (parseInt(submitEl.textContent.trim()) || 0) : 0;
-        var acceptCount = acceptEl ? (parseInt(acceptEl.textContent.trim()) || 0) : 0;
-        var rating = submitCount > 0 ? ((acceptCount / submitCount) * 1000).toFixed(1) : '—';
-
-        var tbodyRows = doc.querySelectorAll('#statics > tbody > tr');
-        var email = '';
-        if (tbodyRows.length > 0) {
-            var lastCells = tbodyRows[tbodyRows.length - 1].querySelectorAll('td');
-            if (lastCells.length >= 2) email = lastCells[1].textContent.trim();
-        }
-
-        var rows = [];
-        if (nickname) rows.push(['昵称', escapeHtml(nickname)]);
-        rows.push(['评分', escapeHtml(acceptCount + ' / ' + submitCount) +
-            ' <span class="text-body-secondary small ms-1">(' + escapeHtml(String(rating)) + ')</span>']);
-        if (email) rows.push(['邮箱', '<a href="mailto:' + escapeHtml(email) + '">' + escapeHtml(email) + '</a>']);
-
-        body.innerHTML = '<dl class="row mb-0">' +
-            rows.map(function(r) {
-                return '<dt class="col-4 text-truncate">' + r[0] + '</dt>' +
-                       '<dd class="col-8 mb-2">' + r[1] + '</dd>';
-            }).join('') +
-            '</dl>';
-    } catch (e) {
-        body.innerHTML = '<p class="text-body-secondary mb-0">无法加载用户信息，请直接访问资料页面。</p>';
+    // ── Badge (render into title) ───────────────────────────────────────────
+    var badge = results[1].status === 'fulfilled' ? results[1].value : null;
+    if (badge && badge.Content) {
+        title.innerHTML = escapeHtml(username) +
+            ' <span class="badge ms-2" style="background-color:' + escapeHtml(badge.BackgroundColor) +
+            ';color:' + escapeHtml(badge.Color) + '">' + escapeHtml(badge.Content) + '</span>';
     }
+
+    // ── Profile (render into body) ──────────────────────────────────────────
+    if (results[0].status === 'rejected') {
+        body.innerHTML = '<p class="text-body-secondary mb-0">无法加载用户信息，请直接访问资料页面。</p>';
+        return;
+    }
+
+    var html = results[0].value;
+
+    if (html.indexOf('No such User!') !== -1) {
+        body.innerHTML = '<p class="text-body-secondary mb-0">用户不存在。</p>';
+        return;
+    }
+
+    var doc = new DOMParser().parseFromString(html, 'text/html');
+
+    var captionEl = doc.querySelector('#statics > caption');
+    var nickname = '';
+    if (captionEl) {
+        // Caption text format: "UserID--Nickname"
+        var parts = captionEl.textContent.trim().split('--');
+        if (parts.length > 1) nickname = parts[1].trim();
+    }
+
+    var submitEl = doc.querySelector('#statics > tbody > tr:nth-child(3) > td:nth-child(2)');
+    var acceptEl = doc.querySelector('#statics > tbody > tr:nth-child(4) > td:nth-child(2)');
+    var submitCount = submitEl ? (parseInt(submitEl.textContent.trim()) || 0) : 0;
+    var acceptCount = acceptEl ? (parseInt(acceptEl.textContent.trim()) || 0) : 0;
+    var rating = submitCount > 0 ? ((acceptCount / submitCount) * 1000).toFixed(1) : '—';
+
+    var tbodyRows = doc.querySelectorAll('#statics > tbody > tr');
+    var email = '';
+    if (tbodyRows.length > 0) {
+        var lastCells = tbodyRows[tbodyRows.length - 1].querySelectorAll('td');
+        if (lastCells.length >= 2) email = lastCells[1].textContent.trim();
+    }
+
+    var rows = [];
+    if (nickname) rows.push(['昵称', escapeHtml(nickname)]);
+    rows.push(['评分', escapeHtml(acceptCount + ' / ' + submitCount) +
+        ' <span class="text-body-secondary small ms-1">(' + escapeHtml(String(rating)) + ')</span>']);
+    if (email) rows.push(['邮箱', '<a href="mailto:' + escapeHtml(email) + '">' + escapeHtml(email) + '</a>']);
+
+    body.innerHTML = '<dl class="row mb-0">' +
+        rows.map(function(r) {
+            return '<dt class="col-4 text-truncate">' + r[0] + '</dt>' +
+                   '<dd class="col-8 mb-2">' + r[1] + '</dd>';
+        }).join('') +
+        '</dl>';
 }
 
 function initUserButtons(container) {
@@ -622,6 +681,7 @@ function renderMailList(query) {
             '</tr>';
     }).join('');
     initUserButtons(tbody);
+    loadBadgesForContainer(tbody);
     tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
         row.addEventListener('click', function(e) {
             if (e.target.closest('.user-info-btn')) return;
@@ -690,6 +750,7 @@ async function loadThread() {
                 '</tr>';
         }).join('');
         initUserButtons(tbody);
+        loadBadgesForContainer(tbody);
         // Make images clickable to zoom
         tbody.querySelectorAll('img').forEach(function(img) {
             img.title = '点击放大';
@@ -697,6 +758,12 @@ async function loadThread() {
                 document.getElementById('img-modal-src').src = img.src;
                 imgModalBS.show();
             });
+            // Re-scroll after each image loads so the bottom stays in view
+            if (atBottom) {
+                img.addEventListener('load', function() {
+                    scrollEl.scrollTop = scrollEl.scrollHeight;
+                });
+            }
         });
         // Make links open in new tab
         tbody.querySelectorAll('a').forEach(function(a) {
@@ -704,7 +771,11 @@ async function loadThread() {
             a.setAttribute('rel', 'noopener noreferrer');
         });
         if (atBottom) {
-            scrollEl.scrollTop = scrollEl.scrollHeight;
+            // Use requestAnimationFrame so the browser has finished laying out
+            // the new rows before we read scrollHeight
+            requestAnimationFrame(function() {
+                scrollEl.scrollTop = scrollEl.scrollHeight;
+            });
         }
         isFirstLoad = false;
     } catch (err) {
@@ -887,7 +958,9 @@ document.getElementById('btn-compose-send').addEventListener('click', sendCompos
 document.getElementById('btn-back').addEventListener('click', function() {
     stopRefresh();
     currentThread = null;
+    document.getElementById('list-search').value = '';
     showScreen('screen-list');
+    renderMailList('');
     loadMailList();
 });
 

--- a/messages.html
+++ b/messages.html
@@ -10,22 +10,11 @@
     <style>
         body { padding-top: 56px; }
         #thread-messages { max-height: 60vh; overflow-y: auto; }
-        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: zoom-in; }
+        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: pointer; }
         .compose-sticky { position: sticky; bottom: 0; background: var(--bs-body-bg); border-top: 1px solid var(--bs-border-color); padding: 0.75rem 0; }
         .msg-bubble-cell { word-break: break-word; max-width: 60vw; }
         #upload-indicator { font-size: 0.8em; }
         .bookmarklet-link { cursor: grab; }
-        .user-info-btn { font-size: inherit; vertical-align: baseline; text-decoration: none; }
-        .user-info-btn:hover { text-decoration: underline; }
-        #img-modal .modal-body { cursor: zoom-out; }
-        #thread-compose { resize: none; overflow-y: hidden; }
-        /* Bootstrap 5.3.3 does not ship dark-mode overrides for .table-primary;
-           supply them here using Bootstrap's own semantic color tokens. */
-        [data-bs-theme="dark"] .table-primary {
-            --bs-table-color: var(--bs-primary-text-emphasis);
-            --bs-table-bg: var(--bs-primary-bg-subtle);
-            --bs-table-border-color: var(--bs-primary-border-subtle);
-        }
     </style>
     <script>
         (function() {
@@ -229,12 +218,6 @@
         </div>
     </div>
 
-    <!-- Search contacts -->
-    <div class="mb-2">
-        <input type="search" class="form-control form-control-sm" id="list-search"
-               placeholder="搜索联系人…" autocomplete="off" autocapitalize="none">
-    </div>
-
     <!-- Compose new message -->
     <div class="collapse mb-3" id="compose-panel">
         <div class="card card-body border-0 shadow-sm">
@@ -253,16 +236,18 @@
     <!-- Mail list table -->
     <div class="table-responsive">
         <table class="table table-hover table-borderless align-middle">
-            <thead>
+            <caption class="caption-top small text-body-secondary pb-1">点击任意行打开对话 &#8594;</caption>
+            <thead class="table-light">
                 <tr>
                     <th>用户</th>
                     <th>最新消息</th>
                     <th class="text-nowrap">时间</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody id="list-tbody">
                 <tr id="list-loading-row">
-                    <td colspan="3" class="text-center text-body-secondary py-4">
+                    <td colspan="4" class="text-center text-body-secondary py-4">
                         <span class="spinner-border spinner-border-sm me-2"></span>加载中…
                     </td>
                 </tr>
@@ -282,7 +267,7 @@
     <!-- Messages table -->
     <div id="thread-messages" class="mb-2">
         <table class="table table-hover table-borderless align-top">
-            <thead>
+            <thead class="table-light">
                 <tr>
                     <th class="text-nowrap">发送者</th>
                     <th>内容</th>
@@ -316,24 +301,6 @@
             </div>
         </div>
         <input type="file" id="file-input" accept="image/png,image/jpeg" style="display:none;">
-    </div>
-</div>
-
-<!-- ==================== USER INFO MODAL ==================== -->
-<div class="modal fade" id="user-info-modal" tabindex="-1">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="user-info-modal-title">用户信息</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-            </div>
-            <div class="modal-body" id="user-info-modal-body"></div>
-            <div class="modal-footer">
-                <a id="user-info-profile-link" href="#" target="_blank" rel="noopener"
-                   class="btn btn-primary">查看完整资料</a>
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>
-            </div>
-        </div>
     </div>
 </div>
 
@@ -381,14 +348,12 @@ let currentUser    = null;   // { username, phpsessid }
 let currentThread  = null;   // other user's username
 let refreshTimer   = null;
 let isFirstLoad    = true;
-let mailListCache  = [];     // last fetched mail list (for local search)
 
 // ── Bootstrap instances ────────────────────────────────────────────────────
-const toastEl        = document.getElementById('app-toast');
-const toastBS        = new bootstrap.Toast(toastEl, { delay: 3500 });
-const imgModalEl     = document.getElementById('img-modal');
-const imgModalBS     = new bootstrap.Modal(imgModalEl);
-const userInfoModalBS = new bootstrap.Modal(document.getElementById('user-info-modal'));
+const toastEl    = document.getElementById('app-toast');
+const toastBS    = new bootstrap.Toast(toastEl, { delay: 3500 });
+const imgModalEl = document.getElementById('img-modal');
+const imgModalBS = new bootstrap.Modal(imgModalEl);
 
 // ── Utility ────────────────────────────────────────────────────────────────
 function showToast(msg, type) {
@@ -434,153 +399,18 @@ function stripMarkdown(md) {
 
 function formatTime(ts) {
     if (!ts) return '';
-    var d = new Date(ts);
+    var d = new Date(ts * 1000);
     var now = new Date();
     var pad = function(n) { return String(n).padStart(2, '0'); };
     if (d.toDateString() === now.toDateString()) {
         return pad(d.getHours()) + ':' + pad(d.getMinutes());
     }
-    var datePart = (d.getFullYear() !== now.getFullYear() ? d.getFullYear() + '/' : '') +
-        (d.getMonth() + 1) + '/' + d.getDate();
-    return datePart + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+    return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 }
 
-function userSpan(username) {
-    return '<button type="button" class="btn btn-link p-0 user-info-btn" ' +
-           'data-username="' + escapeHtml(username) + '">' +
-           escapeHtml(username) + '</button>';
-}
-
-function loadBadgesForContainer(container) {
-    // Group buttons by username in a single DOM pass
-    var byUsername = new Map();
-    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
-        var u = btn.dataset.username;
-        if (!u) return;
-        if (!byUsername.has(u)) byUsername.set(u, []);
-        byUsername.get(u).push(btn);
-    });
-    byUsername.forEach(function(btns, u) {
-        getUserBadge(u).then(function(badge) {
-            if (!badge || !badge.Content) return;
-            btns.forEach(function(b) {
-                // Avoid duplicates on re-render
-                if (b.nextElementSibling && b.nextElementSibling.classList.contains('user-badge')) return;
-                var span = document.createElement('span');
-                span.className = 'badge ms-1 user-badge';
-                span.style.backgroundColor = badge.BackgroundColor;
-                span.style.color = badge.Color;
-                span.textContent = badge.Content;
-                b.insertAdjacentElement('afterend', span);
-            });
-        }).catch(function() {});
-    });
-}
-
-async function getUserBadge(username) {
-    var BADGE_TTL = 1000 * 60 * 60 * 24; // 24 h, matching XMOJ.user.js
-    var prefix = 'UserScript-User-' + username + '-Badge-';
-    var lastUpdate = localStorage.getItem(prefix + 'LastUpdateTime');
-    if (lastUpdate && (Date.now() - parseInt(lastUpdate)) < BADGE_TTL) {
-        return {
-            BackgroundColor: localStorage.getItem(prefix + 'BackgroundColor') || '',
-            Color: localStorage.getItem(prefix + 'Color') || '',
-            Content: localStorage.getItem(prefix + 'Content') || ''
-        };
-    }
-    var result = await apiCall('GetBadge', { UserID: username });
-    var badge = (result && result.Success && result.Data)
-        ? result.Data
-        : { BackgroundColor: '', Color: '', Content: '' };
-    localStorage.setItem(prefix + 'BackgroundColor', badge.BackgroundColor || '');
-    localStorage.setItem(prefix + 'Color', badge.Color || '');
-    localStorage.setItem(prefix + 'Content', badge.Content || '');
-    localStorage.setItem(prefix + 'LastUpdateTime', String(Date.now()));
-    return badge;
-}
-
-async function showUserInfo(username) {
-    var title = document.getElementById('user-info-modal-title');
-    var body = document.getElementById('user-info-modal-body');
-    var profileLink = document.getElementById('user-info-profile-link');
-    var profileUrl = XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username);
-
-    title.textContent = username;
-    profileLink.href = profileUrl;
-    body.innerHTML = '<div class="text-center py-3"><span class="spinner-border spinner-border-sm me-2"></span>加载中…</div>';
-    userInfoModalBS.show();
-
-    var results = await Promise.allSettled([
-        fetch(profileUrl, { referrer: XMOJ_BASE + '/', credentials: 'include' })
-            .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); }),
-        getUserBadge(username)
-    ]);
-
-    // ── Badge (render into title) ───────────────────────────────────────────
-    var badge = results[1].status === 'fulfilled' ? results[1].value : null;
-    if (badge && badge.Content) {
-        title.innerHTML = escapeHtml(username) +
-            ' <span class="badge ms-2" style="background-color:' + escapeHtml(badge.BackgroundColor) +
-            ';color:' + escapeHtml(badge.Color) + '">' + escapeHtml(badge.Content) + '</span>';
-    }
-
-    // ── Profile (render into body) ──────────────────────────────────────────
-    if (results[0].status === 'rejected') {
-        body.innerHTML = '<p class="text-body-secondary mb-0">无法加载用户信息，请直接访问资料页面。</p>';
-        return;
-    }
-
-    var html = results[0].value;
-
-    if (html.indexOf('No such User!') !== -1) {
-        body.innerHTML = '<p class="text-body-secondary mb-0">用户不存在。</p>';
-        return;
-    }
-
-    var doc = new DOMParser().parseFromString(html, 'text/html');
-
-    var captionEl = doc.querySelector('#statics > caption');
-    var nickname = '';
-    if (captionEl) {
-        // Caption text format: "UserID--Nickname"
-        var parts = captionEl.textContent.trim().split('--');
-        if (parts.length > 1) nickname = parts[1].trim();
-    }
-
-    var submitEl = doc.querySelector('#statics > tbody > tr:nth-child(3) > td:nth-child(2)');
-    var acceptEl = doc.querySelector('#statics > tbody > tr:nth-child(4) > td:nth-child(2)');
-    var submitCount = submitEl ? (parseInt(submitEl.textContent.trim()) || 0) : 0;
-    var acceptCount = acceptEl ? (parseInt(acceptEl.textContent.trim()) || 0) : 0;
-    var rating = submitCount > 0 ? ((acceptCount / submitCount) * 1000).toFixed(1) : '—';
-
-    var tbodyRows = doc.querySelectorAll('#statics > tbody > tr');
-    var email = '';
-    if (tbodyRows.length > 0) {
-        var lastCells = tbodyRows[tbodyRows.length - 1].querySelectorAll('td');
-        if (lastCells.length >= 2) email = lastCells[1].textContent.trim();
-    }
-
-    var rows = [];
-    if (nickname) rows.push(['昵称', escapeHtml(nickname)]);
-    rows.push(['评分', escapeHtml(acceptCount + ' / ' + submitCount) +
-        ' <span class="text-body-secondary small ms-1">(' + escapeHtml(String(rating)) + ')</span>']);
-    if (email) rows.push(['邮箱', '<a href="mailto:' + escapeHtml(email) + '">' + escapeHtml(email) + '</a>']);
-
-    body.innerHTML = '<dl class="row mb-0">' +
-        rows.map(function(r) {
-            return '<dt class="col-4 text-truncate">' + r[0] + '</dt>' +
-                   '<dd class="col-8 mb-2">' + r[1] + '</dd>';
-        }).join('') +
-        '</dl>';
-}
-
-function initUserButtons(container) {
-    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
-        btn.addEventListener('click', function(e) {
-            e.stopPropagation();
-            showUserInfo(btn.dataset.username);
-        });
-    });
+function userLink(username) {
+    return '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
+           '" target="_blank" rel="noopener">' + escapeHtml(username) + '</a>';
 }
 
 // ── Theme ──────────────────────────────────────────────────────────────────
@@ -657,39 +487,6 @@ async function apiCall(action, data) {
 }
 
 // ── Mail List ──────────────────────────────────────────────────────────────
-function renderMailList(query) {
-    var tbody = document.getElementById('list-tbody');
-    var q = query ? query.trim().toLowerCase() : '';
-    var list = q
-        ? mailListCache.filter(function(item) { return item.OtherUser.toLowerCase().indexOf(q) !== -1; })
-        : mailListCache;
-    if (list.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-body-secondary py-4">' +
-            (q ? '未找到匹配的联系人' : '暂无消息') + '</td></tr>';
-        return;
-    }
-    tbody.innerHTML = list.map(function(item) {
-        var hasUnread = item.UnreadCount > 0;
-        var preview = stripMarkdown(item.LastsMessage);
-        if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
-        return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
-            '<td>' + userSpan(item.OtherUser) +
-            (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
-            '</td>' +
-            '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
-            '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
-            '</tr>';
-    }).join('');
-    initUserButtons(tbody);
-    loadBadgesForContainer(tbody);
-    tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('.user-info-btn')) return;
-            openThread(row.dataset.user);
-        });
-    });
-}
-
 async function loadMailList() {
     var tbody = document.getElementById('list-tbody');
     tbody.innerHTML = '<tr id="list-loading-row"><td colspan="3" class="text-center text-body-secondary py-4">' +
@@ -697,15 +494,31 @@ async function loadMailList() {
     try {
         var result = await apiCall('GetMailList', {});
         var list = result && result.Data && result.Data.MailList;
-        mailListCache = list || [];
-        if (mailListCache.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="3" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
+        if (!list || list.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
             return;
         }
-        var searchEl = document.getElementById('list-search');
-        renderMailList(searchEl ? searchEl.value : '');
+        tbody.innerHTML = list.map(function(item) {
+            var hasUnread = item.UnreadCount > 0;
+            var preview = stripMarkdown(item.LastsMessage);
+            if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
+            return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
+                '<td>' + userLink(item.OtherUser) +
+                (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
+                '</td>' +
+                '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
+                '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
+                '<td class="text-body-secondary text-end">&#8250;</td>' +
+                '</tr>';
+        }).join('');
+        tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
+            row.addEventListener('click', function(e) {
+                if (e.target.tagName === 'A') return;
+                openThread(row.dataset.user);
+            });
+        });
     } catch (err) {
-        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-danger py-4">加载失败：' + escapeHtml(err.message) + '</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="4" class="text-center text-danger py-4">加载失败：' + escapeHtml(err.message) + '</td></tr>';
         showToast('加载消息列表失败：' + err.message, 'danger');
     }
 }
@@ -743,27 +556,18 @@ async function loadThread() {
             var isUnread = !m.IsRead;
             var isHighlight = isUnread && m.FromUser !== currentUser.username;
             return '<tr class="' + (isHighlight ? 'table-primary' : '') + '">' +
-                '<td class="text-nowrap">' + userSpan(m.FromUser) + '</td>' +
+                '<td class="text-nowrap">' + userLink(m.FromUser) + '</td>' +
                 '<td class="msg-bubble-cell">' + renderMarkdown(m.Content) + '</td>' +
                 '<td class="text-nowrap text-body-secondary small">' + formatTime(m.SendTime) + '</td>' +
                 '<td class="text-nowrap small">' + (isUnread ? '<span class="badge text-bg-warning">未读</span>' : '<span class="text-body-secondary">已读</span>') + '</td>' +
                 '</tr>';
         }).join('');
-        initUserButtons(tbody);
-        loadBadgesForContainer(tbody);
-        // Make images clickable to zoom
+        // Make images clickable
         tbody.querySelectorAll('img').forEach(function(img) {
-            img.title = '点击放大';
             img.addEventListener('click', function() {
                 document.getElementById('img-modal-src').src = img.src;
                 imgModalBS.show();
             });
-            // Re-scroll after each image loads so the bottom stays in view
-            if (atBottom) {
-                img.addEventListener('load', function() {
-                    scrollEl.scrollTop = scrollEl.scrollHeight;
-                });
-            }
         });
         // Make links open in new tab
         tbody.querySelectorAll('a').forEach(function(a) {
@@ -771,11 +575,7 @@ async function loadThread() {
             a.setAttribute('rel', 'noopener noreferrer');
         });
         if (atBottom) {
-            // Use requestAnimationFrame so the browser has finished laying out
-            // the new rows before we read scrollHeight
-            requestAnimationFrame(function() {
-                scrollEl.scrollTop = scrollEl.scrollHeight;
-            });
+            scrollEl.scrollTop = scrollEl.scrollHeight;
         }
         isFirstLoad = false;
     } catch (err) {
@@ -922,17 +722,13 @@ function checkSessionHash() {
 }
 
 // ── Login Tabs ─────────────────────────────────────────────────────────────
-function setLoginTab(tab) {
-    document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) {
-        b.classList.toggle('active', b.dataset.tab === tab);
-    });
-    document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
-    document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
-}
-
 document.querySelectorAll('#loginTabs .nav-link').forEach(function(btn) {
     btn.addEventListener('click', function() {
-        setLoginTab(btn.dataset.tab);
+        document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) { b.classList.remove('active'); });
+        btn.classList.add('active');
+        var tab = btn.dataset.tab;
+        document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
+        document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
     });
 });
 
@@ -949,18 +745,12 @@ document.getElementById('btn-logout').addEventListener('click', logout);
 
 document.getElementById('btn-refresh-list').addEventListener('click', loadMailList);
 
-document.getElementById('list-search').addEventListener('input', function() {
-    renderMailList(this.value);
-});
-
 document.getElementById('btn-compose-send').addEventListener('click', sendCompose);
 
 document.getElementById('btn-back').addEventListener('click', function() {
     stopRefresh();
     currentThread = null;
-    document.getElementById('list-search').value = '';
     showScreen('screen-list');
-    renderMailList('');
     loadMailList();
 });
 
@@ -993,32 +783,6 @@ document.getElementById('thread-compose').addEventListener('paste', function(e) 
     }
 });
 
-// Auto-resize textarea as user types
-(function() {
-    var ta = document.getElementById('thread-compose');
-    function autoResize() {
-        ta.style.height = 'auto';
-        ta.style.height = Math.min(ta.scrollHeight, 200) + 'px';
-    }
-    ta.addEventListener('input', autoResize);
-    autoResize();
-})();
-
-// Global paste handler: upload image from clipboard when in thread view
-document.addEventListener('paste', function(e) {
-    if (document.getElementById('screen-thread').style.display === 'none') return;
-    if (e.defaultPrevented) return; // already handled by local handler
-    var items = e.clipboardData && e.clipboardData.items;
-    if (!items) return;
-    for (var i = 0; i < items.length; i++) {
-        if (items[i].type.startsWith('image/')) {
-            e.preventDefault();
-            handleImageFile(items[i].getAsFile());
-            return;
-        }
-    }
-});
-
 document.getElementById('img-modal-src').addEventListener('click', function() {
     imgModalBS.hide();
 });
@@ -1033,12 +797,6 @@ document.addEventListener('visibilitychange', function() {
 (function init() {
     initTheme();
     initBookmarklet();
-
-    // Set default login tab: bookmarklet on desktop, session login on mobile
-    var isDesktop = window.matchMedia
-        ? window.matchMedia('(pointer: fine)').matches
-        : (!('ontouchstart' in window) && window.innerWidth >= 1024);
-    setLoginTab(isDesktop ? 'bookmarklet' : 'manual');
 
     // Check for bookmarklet redirect
     if (checkSessionHash()) {

--- a/messages.html
+++ b/messages.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="color-scheme" content="light dark">
-    <title>短消息 WebUI — XMOJ-Script</title>
+    <title>短消息在线看 — XMOJ-Script</title>
     <link rel="icon" href="favicon.ico">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
     <style>
@@ -49,7 +49,7 @@
         <div class="collapse navbar-collapse" id="navMain">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                 <li class="nav-item">
-                    <a class="nav-link active" href="messages.html">短消息 WebUI</a>
+                    <a class="nav-link active" href="messages.html">短消息在线看</a>
                 </li>
             </ul>
             <div class="d-flex align-items-center gap-2">
@@ -200,7 +200,7 @@
                 </p>
                 <div class="d-flex gap-2 align-items-start flex-wrap">
                     <a id="bookmarklet-link" href="#" class="btn btn-outline-primary bookmarklet-link"
-                       onclick="return false;" draggable="true">&#128278; 登录到短消息 WebUI</a>
+                       onclick="return false;" draggable="true">&#128278; 登录到短消息在线看</a>
                     <button class="btn btn-outline-secondary btn-sm" id="btn-copy-bookmarklet">复制代码</button>
                 </div>
             </div>

--- a/messages.html
+++ b/messages.html
@@ -51,25 +51,142 @@
 </nav>
 
 <!-- ==================== SCREEN: LOGIN ==================== -->
-<div id="screen-login" class="container py-4" style="max-width:480px;">
-    <h4 class="mb-3">登录</h4>
-    <p class="text-body-secondary small">短消息 WebUI 让您无需安装用户脚本即可收发 XMOJ 站内短消息，适用于 iOS/iPadOS 等不支持用户脚本的设备。</p>
+<div id="screen-login" class="container py-4" style="max-width:520px;">
+    <h4 class="mb-1">登录</h4>
+    <p class="text-body-secondary small mb-3">无需安装用户脚本，在任意浏览器（包括 iOS Safari）收发 XMOJ 站内短消息。</p>
 
     <ul class="nav nav-tabs mb-3" id="loginTabs">
         <li class="nav-item">
-            <button class="nav-link active" data-tab="bookmarklet">书签登录（推荐）</button>
+            <button class="nav-link active" data-tab="manual">会话登录</button>
         </li>
         <li class="nav-item">
-            <button class="nav-link" data-tab="manual">手动输入</button>
+            <button class="nav-link" data-tab="bookmarklet">书签登录（桌面端）</button>
         </li>
     </ul>
 
-    <!-- Tab: Bookmarklet -->
-    <div id="tab-bookmarklet">
+    <!-- Tab: Manual (default) -->
+    <div id="tab-manual">
+        <p class="small text-body-secondary">
+            先在 <a href="https://www.xmoj.tech" target="_blank" rel="noopener">xmoj.tech</a> 完成登录，
+            再按下方说明找到您的用户名和会话 ID（PHPSESSID）并填入。
+        </p>
+
+        <!-- How-to accordion -->
+        <div class="accordion mb-3" id="howto-accordion">
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button collapsed small py-2" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#howto-chrome">
+                        Chrome / Edge / 其他 Chromium 浏览器
+                    </button>
+                </h2>
+                <div id="howto-chrome" class="accordion-collapse collapse" data-bs-parent="#howto-accordion">
+                    <div class="accordion-body small">
+                        <ol class="mb-0 ps-3">
+                            <li>打开 <a href="https://www.xmoj.tech" target="_blank" rel="noopener">xmoj.tech</a> 并登录。</li>
+                            <li>按 <kbd>F12</kbd> 打开开发者工具。</li>
+                            <li>切换到"应用"（Application）标签页。</li>
+                            <li>左侧展开"Cookie" → 点击 <code>https://www.xmoj.tech</code>。</li>
+                            <li>在列表中找到 <code>PHPSESSID</code>，复制其"值"列。</li>
+                            <li>用户名可在页面右上角个人信息处查看。</li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button collapsed small py-2" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#howto-firefox">
+                        Firefox
+                    </button>
+                </h2>
+                <div id="howto-firefox" class="accordion-collapse collapse" data-bs-parent="#howto-accordion">
+                    <div class="accordion-body small">
+                        <ol class="mb-0 ps-3">
+                            <li>打开 <a href="https://www.xmoj.tech" target="_blank" rel="noopener">xmoj.tech</a> 并登录。</li>
+                            <li>按 <kbd>F12</kbd> 打开开发者工具。</li>
+                            <li>切换到"存储"（Storage）标签页。</li>
+                            <li>左侧展开"Cookie" → 点击 <code>https://www.xmoj.tech</code>。</li>
+                            <li>在列表中找到 <code>PHPSESSID</code>，复制其"值"列。</li>
+                            <li>用户名可在页面右上角个人信息处查看。</li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button collapsed small py-2" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#howto-safari-mac">
+                        Safari（macOS）
+                    </button>
+                </h2>
+                <div id="howto-safari-mac" class="accordion-collapse collapse" data-bs-parent="#howto-accordion">
+                    <div class="accordion-body small">
+                        <ol class="mb-0 ps-3">
+                            <li>在菜单栏选择"Safari" → "偏好设置" → "高级"，勾选"在菜单栏中显示开发菜单"。</li>
+                            <li>打开 <a href="https://www.xmoj.tech" target="_blank" rel="noopener">xmoj.tech</a> 并登录。</li>
+                            <li>菜单栏选择"开发" → "显示 Web 检查器"。</li>
+                            <li>切换到"存储"标签页 → "Cookie" → 找到 <code>PHPSESSID</code>。</li>
+                            <li>用户名可在页面右上角个人信息处查看。</li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button collapsed small py-2" type="button"
+                            data-bs-toggle="collapse" data-bs-target="#howto-ios">
+                        iOS / iPadOS Safari
+                    </button>
+                </h2>
+                <div id="howto-ios" class="accordion-collapse collapse" data-bs-parent="#howto-accordion">
+                    <div class="accordion-body small">
+                        <p class="mb-2">iOS Safari 不提供直接查看 Cookie 的界面。有以下两种方法：</p>
+                        <p class="fw-semibold mb-1">方法一：使用桌面端获取后手动输入</p>
+                        <ol class="mb-2 ps-3">
+                            <li>在桌面浏览器（Chrome/Firefox/Safari）中按上方说明找到 PHPSESSID。</li>
+                            <li>将值记录下来，在此处手动填入。</li>
+                        </ol>
+                        <p class="fw-semibold mb-1">方法二：连接 Mac 使用 Safari Web 检查器</p>
+                        <ol class="mb-0 ps-3">
+                            <li>在 iOS 设置 → Safari → 高级 中，打开"Web 检查器"。</li>
+                            <li>用数据线将设备连接到 Mac。</li>
+                            <li>在 Mac 的 Safari → 开发菜单中找到您的设备和 xmoj.tech。</li>
+                            <li>在存储标签页中找到 <code>PHPSESSID</code>。</li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <div class="form-floating mb-3">
+                    <input type="text" class="form-control" id="input-username" placeholder="用户名"
+                           autocomplete="username" autocapitalize="none">
+                    <label for="input-username">用户名</label>
+                </div>
+                <div class="form-floating mb-3">
+                    <input type="text" class="form-control font-monospace" id="input-phpsessid"
+                           placeholder="PHPSESSID" autocomplete="off" autocapitalize="none">
+                    <label for="input-phpsessid">PHPSESSID（会话 ID）</label>
+                </div>
+                <button class="btn btn-primary w-100" id="btn-manual-login">登录</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tab: Bookmarklet (desktop only) -->
+    <div id="tab-bookmarklet" style="display:none;">
+        <div class="alert alert-info small py-2">
+            书签登录仅适用于桌面浏览器（Chrome/Firefox/Edge），移动端请使用"会话登录"。
+        </div>
         <div class="card border-0 shadow-sm mb-3">
             <div class="card-body">
                 <h6 class="card-title">第一步：添加书签</h6>
-                <p class="card-text small text-body-secondary">将下方链接拖动到浏览器书签栏，或复制代码手动新建书签。</p>
+                <p class="card-text small text-body-secondary">
+                    将下方按钮<strong>拖动到书签栏</strong>，或点击"复制代码"后手动新建书签并粘贴为网址。
+                </p>
                 <div class="d-flex gap-2 align-items-start flex-wrap">
                     <a id="bookmarklet-link" href="#" class="btn btn-outline-primary bookmarklet-link"
                        onclick="return false;" draggable="true">&#128278; 登录到短消息 WebUI</a>
@@ -79,30 +196,12 @@
         </div>
         <div class="card border-0 shadow-sm">
             <div class="card-body">
-                <h6 class="card-title">第二步：在 XMOJ 上使用书签</h6>
+                <h6 class="card-title">第二步：在 XMOJ 上点击书签</h6>
                 <ol class="small text-body-secondary mb-0">
-                    <li>前往 <a href="https://www.xmoj.tech" target="_blank">xmoj.tech</a> 并登录。</li>
+                    <li>前往 <a href="https://www.xmoj.tech" target="_blank" rel="noopener">xmoj.tech</a> 并登录。</li>
                     <li>点击刚才添加的书签。</li>
                     <li>页面会自动跳转回此处并完成登录。</li>
                 </ol>
-            </div>
-        </div>
-    </div>
-
-    <!-- Tab: Manual -->
-    <div id="tab-manual" style="display:none;">
-        <div class="card border-0 shadow-sm">
-            <div class="card-body">
-                <p class="small text-body-secondary">在 xmoj.tech 登录后，从 Cookie 中获取 PHPSESSID（可用浏览器开发者工具查看）。</p>
-                <div class="form-floating mb-3">
-                    <input type="text" class="form-control" id="input-username" placeholder="用户名">
-                    <label for="input-username">用户名</label>
-                </div>
-                <div class="form-floating mb-3">
-                    <input type="text" class="form-control font-monospace" id="input-phpsessid" placeholder="PHPSESSID">
-                    <label for="input-phpsessid">PHPSESSID</label>
-                </div>
-                <button class="btn btn-primary w-100" id="btn-manual-login">登录</button>
             </div>
         </div>
     </div>

--- a/messages.html
+++ b/messages.html
@@ -489,7 +489,7 @@ async function apiCall(action, data) {
 // ── Mail List ──────────────────────────────────────────────────────────────
 async function loadMailList() {
     var tbody = document.getElementById('list-tbody');
-    tbody.innerHTML = '<tr id="list-loading-row"><td colspan="3" class="text-center text-body-secondary py-4">' +
+    tbody.innerHTML = '<tr id="list-loading-row"><td colspan="4" class="text-center text-body-secondary py-4">' +
         '<span class="spinner-border spinner-border-sm me-2"></span>加载中…</td></tr>';
     try {
         var result = await apiCall('GetMailList', {});

--- a/messages.html
+++ b/messages.html
@@ -10,11 +10,15 @@
     <style>
         body { padding-top: 56px; }
         #thread-messages { max-height: 60vh; overflow-y: auto; }
-        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: pointer; }
+        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: zoom-in; }
         .compose-sticky { position: sticky; bottom: 0; background: var(--bs-body-bg); border-top: 1px solid var(--bs-border-color); padding: 0.75rem 0; }
         .msg-bubble-cell { word-break: break-word; max-width: 60vw; }
         #upload-indicator { font-size: 0.8em; }
         .bookmarklet-link { cursor: grab; }
+        .user-info-btn { font-size: inherit; vertical-align: baseline; text-decoration: none; }
+        .user-info-btn:hover { text-decoration: underline; }
+        #img-modal .modal-body { cursor: zoom-out; }
+        #thread-compose { resize: none; overflow-y: hidden; }
     </style>
     <script>
         (function() {
@@ -406,10 +410,46 @@ function formatTime(ts) {
     return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 }
 
-function userLink(username) {
-    return '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
-           '" target="_blank" rel="noopener">' + escapeHtml(username) + '</a>';
+// Popover state for user info buttons
+var _activePopoverBtn = null;
+
+function userSpan(username) {
+    return '<button type="button" class="btn btn-link p-0 user-info-btn" ' +
+           'data-username="' + escapeHtml(username) + '">' +
+           escapeHtml(username) + '</button>';
 }
+
+function initUserButtons(container) {
+    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
+        var username = btn.dataset.username;
+        var popover = new bootstrap.Popover(btn, {
+            trigger: 'click',
+            html: true,
+            placement: 'top',
+            title: '<strong>' + escapeHtml(username) + '</strong>',
+            content: '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
+                     '" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary w-100">查看用户资料</a>',
+        });
+        btn.addEventListener('show.bs.popover', function() {
+            if (_activePopoverBtn && _activePopoverBtn !== btn) {
+                var prev = bootstrap.Popover.getInstance(_activePopoverBtn);
+                if (prev) prev.hide();
+            }
+            _activePopoverBtn = btn;
+        });
+        btn.addEventListener('hidden.bs.popover', function() {
+            if (_activePopoverBtn === btn) _activePopoverBtn = null;
+        });
+    });
+}
+
+// Close active popover when clicking outside
+document.addEventListener('click', function(e) {
+    if (_activePopoverBtn && !_activePopoverBtn.contains(e.target) && !e.target.closest('.popover')) {
+        var inst = bootstrap.Popover.getInstance(_activePopoverBtn);
+        if (inst) inst.hide();
+    }
+});
 
 // ── Theme ──────────────────────────────────────────────────────────────────
 function initTheme() {
@@ -501,16 +541,17 @@ async function loadMailList() {
             var preview = stripMarkdown(item.LastsMessage);
             if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
             return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
-                '<td>' + userLink(item.OtherUser) +
+                '<td>' + userSpan(item.OtherUser) +
                 (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
                 '</td>' +
                 '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
                 '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
                 '</tr>';
         }).join('');
+        initUserButtons(tbody);
         tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
             row.addEventListener('click', function(e) {
-                if (e.target.tagName === 'A') return;
+                if (e.target.closest('.user-info-btn') || e.target.closest('.popover')) return;
                 openThread(row.dataset.user);
             });
         });
@@ -553,14 +594,16 @@ async function loadThread() {
             var isUnread = !m.IsRead;
             var isHighlight = isUnread && m.FromUser !== currentUser.username;
             return '<tr class="' + (isHighlight ? 'table-primary' : '') + '">' +
-                '<td class="text-nowrap">' + userLink(m.FromUser) + '</td>' +
+                '<td class="text-nowrap">' + userSpan(m.FromUser) + '</td>' +
                 '<td class="msg-bubble-cell">' + renderMarkdown(m.Content) + '</td>' +
                 '<td class="text-nowrap text-body-secondary small">' + formatTime(m.SendTime) + '</td>' +
                 '<td class="text-nowrap small">' + (isUnread ? '<span class="badge text-bg-warning">未读</span>' : '<span class="text-body-secondary">已读</span>') + '</td>' +
                 '</tr>';
         }).join('');
-        // Make images clickable
+        initUserButtons(tbody);
+        // Make images clickable to zoom
         tbody.querySelectorAll('img').forEach(function(img) {
+            img.title = '点击放大';
             img.addEventListener('click', function() {
                 document.getElementById('img-modal-src').src = img.src;
                 imgModalBS.show();
@@ -719,13 +762,17 @@ function checkSessionHash() {
 }
 
 // ── Login Tabs ─────────────────────────────────────────────────────────────
+function setLoginTab(tab) {
+    document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) {
+        b.classList.toggle('active', b.dataset.tab === tab);
+    });
+    document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
+    document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
+}
+
 document.querySelectorAll('#loginTabs .nav-link').forEach(function(btn) {
     btn.addEventListener('click', function() {
-        document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) { b.classList.remove('active'); });
-        btn.classList.add('active');
-        var tab = btn.dataset.tab;
-        document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
-        document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
+        setLoginTab(btn.dataset.tab);
     });
 });
 
@@ -780,6 +827,32 @@ document.getElementById('thread-compose').addEventListener('paste', function(e) 
     }
 });
 
+// Auto-resize textarea as user types
+(function() {
+    var ta = document.getElementById('thread-compose');
+    function autoResize() {
+        ta.style.height = 'auto';
+        ta.style.height = Math.min(ta.scrollHeight, 200) + 'px';
+    }
+    ta.addEventListener('input', autoResize);
+    autoResize();
+})();
+
+// Global paste handler: upload image from clipboard when in thread view
+document.addEventListener('paste', function(e) {
+    if (document.getElementById('screen-thread').style.display === 'none') return;
+    if (e.defaultPrevented) return; // already handled by local handler
+    var items = e.clipboardData && e.clipboardData.items;
+    if (!items) return;
+    for (var i = 0; i < items.length; i++) {
+        if (items[i].type.startsWith('image/')) {
+            e.preventDefault();
+            handleImageFile(items[i].getAsFile());
+            return;
+        }
+    }
+});
+
 document.getElementById('img-modal-src').addEventListener('click', function() {
     imgModalBS.hide();
 });
@@ -794,6 +867,12 @@ document.addEventListener('visibilitychange', function() {
 (function init() {
     initTheme();
     initBookmarklet();
+
+    // Set default login tab: bookmarklet on desktop, session login on mobile
+    var isDesktop = window.matchMedia
+        ? window.matchMedia('(pointer: fine)').matches
+        : (!('ontouchstart' in window) && window.innerWidth >= 1024);
+    setLoginTab(isDesktop ? 'bookmarklet' : 'manual');
 
     // Check for bookmarklet redirect
     if (checkSessionHash()) {

--- a/messages.html
+++ b/messages.html
@@ -1,0 +1,710 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="light dark">
+    <title>短消息 WebUI — XMOJ-Script</title>
+    <link rel="icon" href="favicon.ico">
+    <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body { padding-top: 56px; }
+        #thread-messages { max-height: 60vh; overflow-y: auto; }
+        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: pointer; }
+        .compose-sticky { position: sticky; bottom: 0; background: var(--bs-body-bg); border-top: 1px solid var(--bs-border-color); padding: 0.75rem 0; }
+        .msg-bubble-cell { word-break: break-word; max-width: 60vw; }
+        #upload-indicator { font-size: 0.8em; }
+        .bookmarklet-link { cursor: grab; }
+    </style>
+    <script>
+        (function() {
+            var t = localStorage.getItem('xmoj-msg-theme') || 'auto';
+            document.documentElement.setAttribute('data-bs-theme',
+                t === 'auto'
+                    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : t);
+        })();
+    </script>
+</head>
+<body>
+
+<!-- Navbar -->
+<nav class="navbar navbar-expand-lg bg-body-tertiary fixed-top">
+    <div class="container">
+        <a class="navbar-brand fw-semibold" href="index.html">XMOJ-Script</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMain">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navMain">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item">
+                    <a class="nav-link active" href="messages.html">短消息 WebUI</a>
+                </li>
+            </ul>
+            <div class="d-flex align-items-center gap-2">
+                <span id="nav-username" class="text-body-secondary small"></span>
+                <button class="btn btn-outline-secondary btn-sm" id="btn-theme" title="切换主题">&#9788;</button>
+                <button class="btn btn-outline-danger btn-sm d-none" id="btn-logout">退出登录</button>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<!-- ==================== SCREEN: LOGIN ==================== -->
+<div id="screen-login" class="container py-4" style="max-width:480px;">
+    <h4 class="mb-3">登录</h4>
+    <p class="text-body-secondary small">短消息 WebUI 让您无需安装用户脚本即可收发 XMOJ 站内短消息，适用于 iOS/iPadOS 等不支持用户脚本的设备。</p>
+
+    <ul class="nav nav-tabs mb-3" id="loginTabs">
+        <li class="nav-item">
+            <button class="nav-link active" data-tab="bookmarklet">书签登录（推荐）</button>
+        </li>
+        <li class="nav-item">
+            <button class="nav-link" data-tab="manual">手动输入</button>
+        </li>
+    </ul>
+
+    <!-- Tab: Bookmarklet -->
+    <div id="tab-bookmarklet">
+        <div class="card border-0 shadow-sm mb-3">
+            <div class="card-body">
+                <h6 class="card-title">第一步：添加书签</h6>
+                <p class="card-text small text-body-secondary">将下方链接拖动到浏览器书签栏，或复制代码手动新建书签。</p>
+                <div class="d-flex gap-2 align-items-start flex-wrap">
+                    <a id="bookmarklet-link" href="#" class="btn btn-outline-primary bookmarklet-link"
+                       onclick="return false;" draggable="true">&#128278; 登录到短消息 WebUI</a>
+                    <button class="btn btn-outline-secondary btn-sm" id="btn-copy-bookmarklet">复制代码</button>
+                </div>
+            </div>
+        </div>
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <h6 class="card-title">第二步：在 XMOJ 上使用书签</h6>
+                <ol class="small text-body-secondary mb-0">
+                    <li>前往 <a href="https://www.xmoj.tech" target="_blank">xmoj.tech</a> 并登录。</li>
+                    <li>点击刚才添加的书签。</li>
+                    <li>页面会自动跳转回此处并完成登录。</li>
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tab: Manual -->
+    <div id="tab-manual" style="display:none;">
+        <div class="card border-0 shadow-sm">
+            <div class="card-body">
+                <p class="small text-body-secondary">在 xmoj.tech 登录后，从 Cookie 中获取 PHPSESSID（可用浏览器开发者工具查看）。</p>
+                <div class="form-floating mb-3">
+                    <input type="text" class="form-control" id="input-username" placeholder="用户名">
+                    <label for="input-username">用户名</label>
+                </div>
+                <div class="form-floating mb-3">
+                    <input type="text" class="form-control font-monospace" id="input-phpsessid" placeholder="PHPSESSID">
+                    <label for="input-phpsessid">PHPSESSID</label>
+                </div>
+                <button class="btn btn-primary w-100" id="btn-manual-login">登录</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ==================== SCREEN: MAIL LIST ==================== -->
+<div id="screen-list" class="container py-3" style="display:none;">
+    <div class="d-flex align-items-center justify-content-between mb-2">
+        <h5 class="mb-0">收件箱</h5>
+        <div class="d-flex gap-2">
+            <button class="btn btn-outline-secondary btn-sm" id="btn-refresh-list" title="刷新">&#8635;</button>
+            <button class="btn btn-primary btn-sm" type="button" data-bs-toggle="collapse"
+                    data-bs-target="#compose-panel">&#43; 新消息</button>
+        </div>
+    </div>
+
+    <!-- Compose new message -->
+    <div class="collapse mb-3" id="compose-panel">
+        <div class="card card-body border-0 shadow-sm">
+            <div class="form-floating mb-2">
+                <input type="text" class="form-control" id="compose-to" placeholder="收件人">
+                <label for="compose-to">收件人用户名</label>
+            </div>
+            <div class="form-floating mb-2">
+                <textarea class="form-control" id="compose-body" placeholder="消息内容" style="height:80px;"></textarea>
+                <label for="compose-body">消息内容</label>
+            </div>
+            <button class="btn btn-primary" id="btn-compose-send">发送</button>
+        </div>
+    </div>
+
+    <!-- Mail list table -->
+    <div class="table-responsive">
+        <table class="table table-hover table-borderless align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>用户</th>
+                    <th>最新消息</th>
+                    <th class="text-nowrap">时间</th>
+                </tr>
+            </thead>
+            <tbody id="list-tbody">
+                <tr id="list-loading-row">
+                    <td colspan="3" class="text-center text-body-secondary py-4">
+                        <span class="spinner-border spinner-border-sm me-2"></span>加载中…
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- ==================== SCREEN: THREAD ==================== -->
+<div id="screen-thread" class="container py-3" style="display:none;">
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <button class="btn btn-outline-secondary btn-sm" id="btn-back">&#8592; 返回</button>
+        <h5 class="mb-0 flex-grow-1" id="thread-title">与 … 的对话</h5>
+        <button class="btn btn-outline-secondary btn-sm" id="btn-refresh-thread" title="刷新">&#8635;</button>
+    </div>
+
+    <!-- Messages table -->
+    <div id="thread-messages" class="mb-2">
+        <table class="table table-hover table-borderless align-top">
+            <thead class="table-light">
+                <tr>
+                    <th class="text-nowrap">发送者</th>
+                    <th>内容</th>
+                    <th class="text-nowrap">时间</th>
+                    <th class="text-nowrap">状态</th>
+                </tr>
+            </thead>
+            <tbody id="thread-tbody">
+                <tr id="thread-loading-row">
+                    <td colspan="4" class="text-center text-body-secondary py-4">
+                        <span class="spinner-border spinner-border-sm me-2"></span>加载中…
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Compose area -->
+    <div class="compose-sticky">
+        <div class="d-flex gap-2 align-items-end">
+            <div class="flex-grow-1">
+                <textarea class="form-control" id="thread-compose" rows="2"
+                          placeholder="输入消息… (Ctrl+Enter 发送)"></textarea>
+                <div id="upload-indicator" class="text-body-secondary mt-1" style="min-height:1.2em;"></div>
+            </div>
+            <div class="d-flex flex-column gap-1">
+                <button class="btn btn-outline-secondary btn-sm" id="btn-upload-image" title="上传图片">&#128247;</button>
+                <button class="btn btn-primary" id="btn-thread-send">
+                    <span id="send-spinner" class="spinner-border spinner-border-sm d-none me-1"></span>发送
+                </button>
+            </div>
+        </div>
+        <input type="file" id="file-input" accept="image/png,image/jpeg" style="display:none;">
+    </div>
+</div>
+
+<!-- ==================== IMAGE VIEWER MODAL ==================== -->
+<div class="modal fade" id="img-modal" tabindex="-1">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
+        <div class="modal-content bg-transparent border-0">
+            <div class="modal-body p-0 text-center">
+                <img id="img-modal-src" src="" alt="" class="img-fluid" style="cursor:pointer; max-height:90vh;">
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ==================== TOAST ==================== -->
+<div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index:9999;">
+    <div id="app-toast" class="toast align-items-center border-0" role="alert">
+        <div class="d-flex">
+            <div class="toast-body" id="toast-body">消息</div>
+            <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast"></button>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.3/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/marked/9.1.6/marked.min.js"></script>
+<script src="https://cdn.bootcdn.net/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
+<script>
+'use strict';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+const API_BASE          = 'https://api.xmoj-bbs.me/';
+const ASSET_BASE        = 'https://assets.xmoj-bbs.me/GetImage?ImageID=';
+const XMOJ_BASE        = 'https://www.xmoj.tech';
+const WEBUI_VERSION     = 'webui-1.0.0';
+const STORAGE_USER      = 'xmoj-msg-username';
+const STORAGE_SESSION   = 'xmoj-msg-phpsessid';
+const THREAD_REFRESH_MS = 10000;
+const SCROLL_THRESHOLD  = 80;
+const MAX_IMAGE_BYTES   = 5 * 1024 * 1024;
+const PREVIEW_LEN       = 60;
+
+// ── State ──────────────────────────────────────────────────────────────────
+let currentUser    = null;   // { username, phpsessid }
+let currentThread  = null;   // other user's username
+let refreshTimer   = null;
+let isFirstLoad    = true;
+
+// ── Bootstrap instances ────────────────────────────────────────────────────
+const toastEl    = document.getElementById('app-toast');
+const toastBS    = new bootstrap.Toast(toastEl, { delay: 3500 });
+const imgModalEl = document.getElementById('img-modal');
+const imgModalBS = new bootstrap.Modal(imgModalEl);
+
+// ── Utility ────────────────────────────────────────────────────────────────
+function showToast(msg, type) {
+    const body = document.getElementById('toast-body');
+    body.textContent = msg;
+    toastEl.className = 'toast align-items-center border-0 text-bg-' + (type || 'secondary');
+    toastBS.show();
+}
+
+function showScreen(id) {
+    ['screen-login', 'screen-list', 'screen-thread'].forEach(function(s) {
+        document.getElementById(s).style.display = s === id ? '' : 'none';
+    });
+}
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function renderMarkdown(md) {
+    var html = marked.parse(String(md || ''));
+    return DOMPurify.sanitize(html, {
+        ALLOWED_TAGS: ['p','br','strong','em','del','code','pre','blockquote',
+                       'ul','ol','li','a','img','h1','h2','h3','h4','h5','h6','table',
+                       'thead','tbody','tr','th','td','hr','span'],
+        ALLOWED_ATTR: ['href','src','alt','title','class','target','rel'],
+        FORCE_BODY: true,
+        ADD_ATTR: ['target'],
+        FORBID_SCRIPT: true,
+    });
+}
+
+function stripMarkdown(md) {
+    return String(md || '').replace(/!\[.*?\]\(.*?\)/g, '[图片]')
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+        .replace(/[*_`#>~]/g, '')
+        .replace(/\s+/g, ' ').trim();
+}
+
+function formatTime(ts) {
+    if (!ts) return '';
+    var d = new Date(ts * 1000);
+    var now = new Date();
+    var pad = function(n) { return String(n).padStart(2, '0'); };
+    if (d.toDateString() === now.toDateString()) {
+        return pad(d.getHours()) + ':' + pad(d.getMinutes());
+    }
+    return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+}
+
+function userLink(username) {
+    return '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
+           '" target="_blank" rel="noopener">' + escapeHtml(username) + '</a>';
+}
+
+// ── Theme ──────────────────────────────────────────────────────────────────
+function initTheme() {
+    var t = localStorage.getItem('xmoj-msg-theme') || 'auto';
+    applyTheme(t);
+}
+
+function applyTheme(t) {
+    var resolved = t === 'auto'
+        ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+        : t;
+    document.documentElement.setAttribute('data-bs-theme', resolved);
+    localStorage.setItem('xmoj-msg-theme', t);
+    document.getElementById('btn-theme').title = '当前：' + (t === 'auto' ? '自动' : t === 'dark' ? '深色' : '浅色');
+}
+
+document.getElementById('btn-theme').addEventListener('click', function() {
+    var order = ['auto', 'dark', 'light'];
+    var cur = localStorage.getItem('xmoj-msg-theme') || 'auto';
+    var next = order[(order.indexOf(cur) + 1) % order.length];
+    applyTheme(next);
+});
+
+// ── Session ────────────────────────────────────────────────────────────────
+function saveSession(username, phpsessid) {
+    localStorage.setItem(STORAGE_USER, username);
+    localStorage.setItem(STORAGE_SESSION, phpsessid);
+    currentUser = { username: username, phpsessid: phpsessid };
+}
+
+function loadSession() {
+    var u = localStorage.getItem(STORAGE_USER);
+    var s = localStorage.getItem(STORAGE_SESSION);
+    if (u && s) {
+        currentUser = { username: u, phpsessid: s };
+        return true;
+    }
+    return false;
+}
+
+function logout() {
+    localStorage.removeItem(STORAGE_USER);
+    localStorage.removeItem(STORAGE_SESSION);
+    currentUser = null;
+    currentThread = null;
+    stopRefresh();
+    document.getElementById('nav-username').textContent = '';
+    document.getElementById('btn-logout').classList.add('d-none');
+    showScreen('screen-login');
+}
+
+function onLoggedIn() {
+    document.getElementById('nav-username').textContent = currentUser.username;
+    document.getElementById('btn-logout').classList.remove('d-none');
+    loadMailList();
+    showScreen('screen-list');
+}
+
+// ── API ────────────────────────────────────────────────────────────────────
+async function apiCall(action, data) {
+    var res = await fetch(API_BASE + action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            Authentication: { SessionID: currentUser.phpsessid, Username: currentUser.username },
+            Data: data,
+            Version: WEBUI_VERSION
+        })
+    });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    return res.json();
+}
+
+// ── Mail List ──────────────────────────────────────────────────────────────
+async function loadMailList() {
+    var tbody = document.getElementById('list-tbody');
+    tbody.innerHTML = '<tr id="list-loading-row"><td colspan="3" class="text-center text-body-secondary py-4">' +
+        '<span class="spinner-border spinner-border-sm me-2"></span>加载中…</td></tr>';
+    try {
+        var result = await apiCall('GetMailList', {});
+        var list = result && result.Data && result.Data.MailList;
+        if (!list || list.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="3" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
+            return;
+        }
+        tbody.innerHTML = list.map(function(item) {
+            var hasUnread = item.UnreadCount > 0;
+            var preview = stripMarkdown(item.LastsMessage);
+            if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
+            return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
+                '<td>' + userLink(item.OtherUser) +
+                (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
+                '</td>' +
+                '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
+                '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
+                '</tr>';
+        }).join('');
+        tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
+            row.addEventListener('click', function(e) {
+                if (e.target.tagName === 'A') return;
+                openThread(row.dataset.user);
+            });
+        });
+    } catch (err) {
+        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-danger py-4">加载失败：' + escapeHtml(err.message) + '</td></tr>';
+        showToast('加载消息列表失败：' + err.message, 'danger');
+    }
+}
+
+// ── Thread ─────────────────────────────────────────────────────────────────
+function openThread(otherUser) {
+    currentThread = otherUser;
+    isFirstLoad = true;
+    document.getElementById('thread-title').textContent = '与 ' + otherUser + ' 的对话';
+    document.getElementById('thread-tbody').innerHTML =
+        '<tr id="thread-loading-row"><td colspan="4" class="text-center text-body-secondary py-4">' +
+        '<span class="spinner-border spinner-border-sm me-2"></span>加载中…</td></tr>';
+    showScreen('screen-thread');
+    loadThread();
+    startRefresh();
+    // Mark as read (fire-and-forget)
+    apiCall('ReadUserMailMention', { UserID: otherUser }).catch(function() {});
+}
+
+async function loadThread() {
+    if (!currentThread) return;
+    var scrollEl = document.getElementById('thread-messages');
+    var atBottom = isFirstLoad ||
+        (scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight < SCROLL_THRESHOLD);
+    try {
+        var result = await apiCall('GetMail', { OtherUser: currentThread });
+        var mails = result && result.Data && result.Data.Mail;
+        var tbody = document.getElementById('thread-tbody');
+        if (!mails || mails.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
+            return;
+        }
+        tbody.innerHTML = mails.map(function(m) {
+            var isUnread = !m.IsRead && m.FromUser !== currentUser.username;
+            return '<tr class="' + (isUnread ? 'table-primary' : '') + '">' +
+                '<td class="text-nowrap">' + userLink(m.FromUser) + '</td>' +
+                '<td class="msg-bubble-cell">' + renderMarkdown(m.Content) + '</td>' +
+                '<td class="text-nowrap text-body-secondary small">' + formatTime(m.SendTime) + '</td>' +
+                '<td class="text-nowrap small">' + (isUnread ? '<span class="badge text-bg-warning">未读</span>' : '<span class="text-body-secondary">已读</span>') + '</td>' +
+                '</tr>';
+        }).join('');
+        // Make images clickable
+        tbody.querySelectorAll('img').forEach(function(img) {
+            img.addEventListener('click', function() {
+                document.getElementById('img-modal-src').src = img.src;
+                imgModalBS.show();
+            });
+        });
+        // Make links open in new tab
+        tbody.querySelectorAll('a').forEach(function(a) {
+            a.setAttribute('target', '_blank');
+            a.setAttribute('rel', 'noopener noreferrer');
+        });
+        if (atBottom) {
+            scrollEl.scrollTop = scrollEl.scrollHeight;
+        }
+        isFirstLoad = false;
+    } catch (err) {
+        showToast('加载消息失败：' + err.message, 'danger');
+    }
+}
+
+// ── Send Message ───────────────────────────────────────────────────────────
+async function sendMessage() {
+    var textarea = document.getElementById('thread-compose');
+    var btn = document.getElementById('btn-thread-send');
+    var spinner = document.getElementById('send-spinner');
+    var content = textarea.value.trim();
+    if (!content) return;
+    btn.disabled = true;
+    spinner.classList.remove('d-none');
+    try {
+        await apiCall('SendMail', { ToUser: currentThread, Content: content });
+        textarea.value = '';
+        await loadThread();
+    } catch (err) {
+        showToast('发送失败：' + err.message, 'danger');
+    } finally {
+        btn.disabled = false;
+        spinner.classList.add('d-none');
+    }
+}
+
+// ── Compose (from list) ────────────────────────────────────────────────────
+async function sendCompose() {
+    var toInput = document.getElementById('compose-to');
+    var bodyInput = document.getElementById('compose-body');
+    var btn = document.getElementById('btn-compose-send');
+    var to = toInput.value.trim();
+    var content = bodyInput.value.trim();
+    if (!to || !content) { showToast('请填写收件人和消息内容', 'warning'); return; }
+    btn.disabled = true;
+    btn.textContent = '发送中…';
+    try {
+        await apiCall('SendMail', { ToUser: to, Content: content });
+        toInput.value = '';
+        bodyInput.value = '';
+        bootstrap.Collapse.getInstance(document.getElementById('compose-panel')).hide();
+        showToast('发送成功', 'success');
+        await loadMailList();
+    } catch (err) {
+        showToast('发送失败：' + err.message, 'danger');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = '发送';
+    }
+}
+
+// ── Image Upload ───────────────────────────────────────────────────────────
+function setUploadIndicator(msg) {
+    document.getElementById('upload-indicator').textContent = msg;
+}
+
+async function uploadImageData(dataUrl) {
+    var textarea = document.getElementById('thread-compose');
+    var placeholder = '![上传中…]()';
+    textarea.value += '\n' + placeholder;
+    setUploadIndicator('图片上传中…');
+    try {
+        var result = await apiCall('UploadImage', { Image: dataUrl });
+        var imageId = result && result.Data && result.Data.ImageID;
+        if (!imageId) throw new Error('未获取到 ImageID');
+        var mdImg = '![图片](' + ASSET_BASE + imageId + ')';
+        textarea.value = textarea.value.replace(placeholder, mdImg);
+        setUploadIndicator('');
+        showToast('图片上传成功', 'success');
+    } catch (err) {
+        textarea.value = textarea.value.replace('\n' + placeholder, '');
+        setUploadIndicator('');
+        showToast('图片上传失败：' + err.message, 'danger');
+    }
+}
+
+function handleImageFile(file) {
+    if (!file) return;
+    if (!['image/png', 'image/jpeg'].includes(file.type)) {
+        showToast('仅支持 PNG 和 JPEG 图片', 'warning');
+        return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+        showToast('图片大小不能超过 5 MB', 'warning');
+        return;
+    }
+    var reader = new FileReader();
+    reader.onload = function(e) { uploadImageData(e.target.result); };
+    reader.readAsDataURL(file);
+}
+
+// ── Auto Refresh ───────────────────────────────────────────────────────────
+function startRefresh() {
+    stopRefresh();
+    refreshTimer = setInterval(loadThread, THREAD_REFRESH_MS);
+}
+
+function stopRefresh() {
+    if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; }
+}
+
+// ── Bookmarklet ────────────────────────────────────────────────────────────
+function generateBookmarklet() {
+    var dest = location.origin + location.pathname;
+    // The bookmarklet reads cookie + username from XMOJ and redirects here
+    var code = '(function(){' +
+        'var m=document.cookie.match(/PHPSESSID=([^;]+)/);' +
+        'var s=m?m[1]:"";' +
+        'var el=document.querySelector("#profile a")||document.querySelector("#profile");' +
+        'var n=el?el.textContent.trim():"";' +
+        'if(!s||!n){alert("请先登录 XMOJ！");}' +
+        'else{location.href=' + JSON.stringify(dest) + '+"#session="+encodeURIComponent(n)+":"+encodeURIComponent(s);}' +
+        '})();';
+    return 'javascript:' + code;
+}
+
+function initBookmarklet() {
+    var link = document.getElementById('bookmarklet-link');
+    var code = generateBookmarklet();
+    link.href = code;
+    document.getElementById('btn-copy-bookmarklet').addEventListener('click', function() {
+        navigator.clipboard.writeText(code).then(function() {
+            showToast('已复制到剪贴板', 'success');
+        }).catch(function() {
+            showToast('复制失败，请手动复制', 'warning');
+        });
+    });
+}
+
+function checkSessionHash() {
+    var hash = location.hash;
+    if (!hash.startsWith('#session=')) return false;
+    var val = decodeURIComponent(hash.slice('#session='.length));
+    var idx = val.indexOf(':');
+    if (idx < 1) return false;
+    var username = val.slice(0, idx);
+    var phpsessid = val.slice(idx + 1);
+    if (!username || !phpsessid) return false;
+    saveSession(username, phpsessid);
+    history.replaceState(null, '', location.pathname);
+    return true;
+}
+
+// ── Login Tabs ─────────────────────────────────────────────────────────────
+document.querySelectorAll('#loginTabs .nav-link').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) { b.classList.remove('active'); });
+        btn.classList.add('active');
+        var tab = btn.dataset.tab;
+        document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
+        document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
+    });
+});
+
+// ── Event Wiring ───────────────────────────────────────────────────────────
+document.getElementById('btn-manual-login').addEventListener('click', function() {
+    var username = document.getElementById('input-username').value.trim();
+    var phpsessid = document.getElementById('input-phpsessid').value.trim();
+    if (!username || !phpsessid) { showToast('请填写用户名和 PHPSESSID', 'warning'); return; }
+    saveSession(username, phpsessid);
+    onLoggedIn();
+});
+
+document.getElementById('btn-logout').addEventListener('click', logout);
+
+document.getElementById('btn-refresh-list').addEventListener('click', loadMailList);
+
+document.getElementById('btn-compose-send').addEventListener('click', sendCompose);
+
+document.getElementById('btn-back').addEventListener('click', function() {
+    stopRefresh();
+    currentThread = null;
+    showScreen('screen-list');
+    loadMailList();
+});
+
+document.getElementById('btn-refresh-thread').addEventListener('click', loadThread);
+
+document.getElementById('btn-thread-send').addEventListener('click', sendMessage);
+
+document.getElementById('thread-compose').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter' && e.ctrlKey) { e.preventDefault(); sendMessage(); }
+});
+
+document.getElementById('btn-upload-image').addEventListener('click', function() {
+    document.getElementById('file-input').click();
+});
+
+document.getElementById('file-input').addEventListener('change', function(e) {
+    handleImageFile(e.target.files[0]);
+    e.target.value = '';
+});
+
+document.getElementById('thread-compose').addEventListener('paste', function(e) {
+    var items = e.clipboardData && e.clipboardData.items;
+    if (!items) return;
+    for (var i = 0; i < items.length; i++) {
+        if (items[i].type.startsWith('image/')) {
+            e.preventDefault();
+            handleImageFile(items[i].getAsFile());
+            return;
+        }
+    }
+});
+
+document.getElementById('img-modal-src').addEventListener('click', function() {
+    imgModalBS.hide();
+});
+
+// Pause auto-refresh when tab is hidden
+document.addEventListener('visibilitychange', function() {
+    if (document.hidden) { stopRefresh(); }
+    else if (currentThread) { loadThread(); startRefresh(); }
+});
+
+// ── Boot ───────────────────────────────────────────────────────────────────
+(function init() {
+    initTheme();
+    initBookmarklet();
+
+    // Check for bookmarklet redirect
+    if (checkSessionHash()) {
+        onLoggedIn();
+        return;
+    }
+
+    if (loadSession()) {
+        onLoggedIn();
+    } else {
+        showScreen('screen-login');
+    }
+})();
+</script>
+</body>
+</html>

--- a/messages.html
+++ b/messages.html
@@ -19,6 +19,13 @@
         .user-info-btn:hover { text-decoration: underline; }
         #img-modal .modal-body { cursor: zoom-out; }
         #thread-compose { resize: none; overflow-y: hidden; }
+        /* Bootstrap 5.3.3 does not ship dark-mode overrides for .table-primary;
+           supply them here using Bootstrap's own semantic color tokens. */
+        [data-bs-theme="dark"] .table-primary {
+            --bs-table-color: var(--bs-primary-text-emphasis);
+            --bs-table-bg: var(--bs-primary-bg-subtle);
+            --bs-table-border-color: var(--bs-primary-border-subtle);
+        }
     </style>
     <script>
         (function() {
@@ -306,6 +313,24 @@
     </div>
 </div>
 
+<!-- ==================== USER INFO MODAL ==================== -->
+<div class="modal fade" id="user-info-modal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="user-info-modal-title">用户信息</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body" id="user-info-modal-body"></div>
+            <div class="modal-footer">
+                <a id="user-info-profile-link" href="#" target="_blank" rel="noopener"
+                   class="btn btn-primary">查看完整资料</a>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- ==================== IMAGE VIEWER MODAL ==================== -->
 <div class="modal fade" id="img-modal" tabindex="-1">
     <div class="modal-dialog modal-xl modal-dialog-centered">
@@ -352,10 +377,11 @@ let refreshTimer   = null;
 let isFirstLoad    = true;
 
 // ── Bootstrap instances ────────────────────────────────────────────────────
-const toastEl    = document.getElementById('app-toast');
-const toastBS    = new bootstrap.Toast(toastEl, { delay: 3500 });
-const imgModalEl = document.getElementById('img-modal');
-const imgModalBS = new bootstrap.Modal(imgModalEl);
+const toastEl        = document.getElementById('app-toast');
+const toastBS        = new bootstrap.Toast(toastEl, { delay: 3500 });
+const imgModalEl     = document.getElementById('img-modal');
+const imgModalBS     = new bootstrap.Modal(imgModalEl);
+const userInfoModalBS = new bootstrap.Modal(document.getElementById('user-info-modal'));
 
 // ── Utility ────────────────────────────────────────────────────────────────
 function showToast(msg, type) {
@@ -401,7 +427,7 @@ function stripMarkdown(md) {
 
 function formatTime(ts) {
     if (!ts) return '';
-    var d = new Date(ts * 1000);
+    var d = new Date(ts);
     var now = new Date();
     var pad = function(n) { return String(n).padStart(2, '0'); };
     if (d.toDateString() === now.toDateString()) {
@@ -412,46 +438,81 @@ function formatTime(ts) {
     return datePart + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 }
 
-// Popover state for user info buttons
-var _activePopoverBtn = null;
-
 function userSpan(username) {
     return '<button type="button" class="btn btn-link p-0 user-info-btn" ' +
            'data-username="' + escapeHtml(username) + '">' +
            escapeHtml(username) + '</button>';
 }
 
+async function showUserInfo(username) {
+    var title = document.getElementById('user-info-modal-title');
+    var body = document.getElementById('user-info-modal-body');
+    var profileLink = document.getElementById('user-info-profile-link');
+    var profileUrl = XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username);
+
+    title.textContent = username;
+    profileLink.href = profileUrl;
+    body.innerHTML = '<div class="text-center py-3"><span class="spinner-border spinner-border-sm me-2"></span>加载中…</div>';
+    userInfoModalBS.show();
+
+    try {
+        var res = await fetch(profileUrl);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        var html = await res.text();
+
+        if (html.indexOf('No such User!') !== -1) {
+            body.innerHTML = '<p class="text-body-secondary mb-0">用户不存在。</p>';
+            return;
+        }
+
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+
+        var captionEl = doc.querySelector('#statics > caption');
+        var nickname = '';
+        if (captionEl) {
+            // Caption text format: "UserID--Nickname"
+            var parts = captionEl.textContent.trim().split('--');
+            if (parts.length > 1) nickname = parts[1].trim();
+        }
+
+        var submitEl = doc.querySelector('#statics > tbody > tr:nth-child(3) > td:nth-child(2)');
+        var acceptEl = doc.querySelector('#statics > tbody > tr:nth-child(4) > td:nth-child(2)');
+        var submitCount = submitEl ? (parseInt(submitEl.textContent.trim()) || 0) : 0;
+        var acceptCount = acceptEl ? (parseInt(acceptEl.textContent.trim()) || 0) : 0;
+        var rating = submitCount > 0 ? ((acceptCount / submitCount) * 1000).toFixed(1) : '—';
+
+        var tbodyRows = doc.querySelectorAll('#statics > tbody > tr');
+        var email = '';
+        if (tbodyRows.length > 0) {
+            var lastCells = tbodyRows[tbodyRows.length - 1].querySelectorAll('td');
+            if (lastCells.length >= 2) email = lastCells[1].textContent.trim();
+        }
+
+        var rows = [];
+        if (nickname) rows.push(['昵称', escapeHtml(nickname)]);
+        rows.push(['评分', escapeHtml(acceptCount + ' / ' + submitCount) +
+            ' <span class="text-body-secondary small ms-1">(' + escapeHtml(String(rating)) + ')</span>']);
+        if (email) rows.push(['邮箱', '<a href="mailto:' + escapeHtml(email) + '">' + escapeHtml(email) + '</a>']);
+
+        body.innerHTML = '<dl class="row mb-0">' +
+            rows.map(function(r) {
+                return '<dt class="col-4 text-truncate">' + r[0] + '</dt>' +
+                       '<dd class="col-8 mb-2">' + r[1] + '</dd>';
+            }).join('') +
+            '</dl>';
+    } catch (e) {
+        body.innerHTML = '<p class="text-body-secondary mb-0">无法加载用户信息，请直接访问资料页面。</p>';
+    }
+}
+
 function initUserButtons(container) {
     container.querySelectorAll('.user-info-btn').forEach(function(btn) {
-        var username = btn.dataset.username;
-        var popover = new bootstrap.Popover(btn, {
-            trigger: 'click',
-            html: true,
-            placement: 'top',
-            title: '<strong>' + escapeHtml(username) + '</strong>',
-            content: '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
-                     '" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary w-100">查看用户资料</a>',
-        });
-        btn.addEventListener('show.bs.popover', function() {
-            if (_activePopoverBtn && _activePopoverBtn !== btn) {
-                var prev = bootstrap.Popover.getInstance(_activePopoverBtn);
-                if (prev) prev.hide();
-            }
-            _activePopoverBtn = btn;
-        });
-        btn.addEventListener('hidden.bs.popover', function() {
-            if (_activePopoverBtn === btn) _activePopoverBtn = null;
+        btn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            showUserInfo(btn.dataset.username);
         });
     });
 }
-
-// Close active popover when clicking outside
-document.addEventListener('click', function(e) {
-    if (_activePopoverBtn && !_activePopoverBtn.contains(e.target) && !e.target.closest('.popover')) {
-        var inst = bootstrap.Popover.getInstance(_activePopoverBtn);
-        if (inst) inst.hide();
-    }
-});
 
 // ── Theme ──────────────────────────────────────────────────────────────────
 function initTheme() {
@@ -553,7 +614,7 @@ async function loadMailList() {
         initUserButtons(tbody);
         tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
             row.addEventListener('click', function(e) {
-                if (e.target.closest('.user-info-btn') || e.target.closest('.popover')) return;
+                if (e.target.closest('.user-info-btn')) return;
                 openThread(row.dataset.user);
             });
         });

--- a/messages.html
+++ b/messages.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="light dark">
     <title>短消息 WebUI — XMOJ-Script</title>
     <link rel="icon" href="favicon.ico">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body { padding-top: 56px; }
         #thread-messages { max-height: 60vh; overflow-y: auto; }
@@ -224,9 +224,9 @@
     </div>
 </div>
 
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/9.1.6/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
 <script>
 'use strict';
 

--- a/messages.html
+++ b/messages.html
@@ -10,11 +10,22 @@
     <style>
         body { padding-top: 56px; }
         #thread-messages { max-height: 60vh; overflow-y: auto; }
-        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: pointer; }
+        #thread-messages img { max-width: 100%; max-height: 300px; object-fit: contain; cursor: zoom-in; }
         .compose-sticky { position: sticky; bottom: 0; background: var(--bs-body-bg); border-top: 1px solid var(--bs-border-color); padding: 0.75rem 0; }
         .msg-bubble-cell { word-break: break-word; max-width: 60vw; }
         #upload-indicator { font-size: 0.8em; }
         .bookmarklet-link { cursor: grab; }
+        .user-info-btn { font-size: inherit; vertical-align: baseline; text-decoration: none; }
+        .user-info-btn:hover { text-decoration: underline; }
+        #img-modal .modal-body { cursor: zoom-out; }
+        #thread-compose { resize: none; overflow-y: hidden; }
+        /* Bootstrap 5.3.3 does not ship dark-mode overrides for .table-primary;
+           supply them here using Bootstrap's own semantic color tokens. */
+        [data-bs-theme="dark"] .table-primary {
+            --bs-table-color: var(--bs-primary-text-emphasis);
+            --bs-table-bg: var(--bs-primary-bg-subtle);
+            --bs-table-border-color: var(--bs-primary-border-subtle);
+        }
     </style>
     <script>
         (function() {
@@ -218,6 +229,12 @@
         </div>
     </div>
 
+    <!-- Search contacts -->
+    <div class="mb-2">
+        <input type="search" class="form-control form-control-sm" id="list-search"
+               placeholder="搜索联系人…" autocomplete="off" autocapitalize="none">
+    </div>
+
     <!-- Compose new message -->
     <div class="collapse mb-3" id="compose-panel">
         <div class="card card-body border-0 shadow-sm">
@@ -237,7 +254,7 @@
     <div class="table-responsive">
         <table class="table table-hover table-borderless align-middle">
             <caption class="caption-top small text-body-secondary pb-1">点击任意行打开对话 &#8594;</caption>
-            <thead class="table-light">
+            <thead>
                 <tr>
                     <th>用户</th>
                     <th>最新消息</th>
@@ -267,7 +284,7 @@
     <!-- Messages table -->
     <div id="thread-messages" class="mb-2">
         <table class="table table-hover table-borderless align-top">
-            <thead class="table-light">
+            <thead>
                 <tr>
                     <th class="text-nowrap">发送者</th>
                     <th>内容</th>
@@ -301,6 +318,24 @@
             </div>
         </div>
         <input type="file" id="file-input" accept="image/png,image/jpeg" style="display:none;">
+    </div>
+</div>
+
+<!-- ==================== USER INFO MODAL ==================== -->
+<div class="modal fade" id="user-info-modal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="user-info-modal-title">用户信息</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body" id="user-info-modal-body"></div>
+            <div class="modal-footer">
+                <a id="user-info-profile-link" href="#" target="_blank" rel="noopener"
+                   class="btn btn-primary">查看完整资料</a>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -348,12 +383,14 @@ let currentUser    = null;   // { username, phpsessid }
 let currentThread  = null;   // other user's username
 let refreshTimer   = null;
 let isFirstLoad    = true;
+let mailListCache  = [];     // last fetched mail list (for local search)
 
 // ── Bootstrap instances ────────────────────────────────────────────────────
-const toastEl    = document.getElementById('app-toast');
-const toastBS    = new bootstrap.Toast(toastEl, { delay: 3500 });
-const imgModalEl = document.getElementById('img-modal');
-const imgModalBS = new bootstrap.Modal(imgModalEl);
+const toastEl        = document.getElementById('app-toast');
+const toastBS        = new bootstrap.Toast(toastEl, { delay: 3500 });
+const imgModalEl     = document.getElementById('img-modal');
+const imgModalBS     = new bootstrap.Modal(imgModalEl);
+const userInfoModalBS = new bootstrap.Modal(document.getElementById('user-info-modal'));
 
 // ── Utility ────────────────────────────────────────────────────────────────
 function showToast(msg, type) {
@@ -399,18 +436,153 @@ function stripMarkdown(md) {
 
 function formatTime(ts) {
     if (!ts) return '';
-    var d = new Date(ts * 1000);
+    var d = new Date(ts);
     var now = new Date();
     var pad = function(n) { return String(n).padStart(2, '0'); };
     if (d.toDateString() === now.toDateString()) {
         return pad(d.getHours()) + ':' + pad(d.getMinutes());
     }
-    return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+    var datePart = (d.getFullYear() !== now.getFullYear() ? d.getFullYear() + '/' : '') +
+        (d.getMonth() + 1) + '/' + d.getDate();
+    return datePart + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 }
 
-function userLink(username) {
-    return '<a href="' + XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username) +
-           '" target="_blank" rel="noopener">' + escapeHtml(username) + '</a>';
+function userSpan(username) {
+    return '<button type="button" class="btn btn-link p-0 user-info-btn" ' +
+           'data-username="' + escapeHtml(username) + '">' +
+           escapeHtml(username) + '</button>';
+}
+
+function loadBadgesForContainer(container) {
+    // Group buttons by username in a single DOM pass
+    var byUsername = new Map();
+    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
+        var u = btn.dataset.username;
+        if (!u) return;
+        if (!byUsername.has(u)) byUsername.set(u, []);
+        byUsername.get(u).push(btn);
+    });
+    byUsername.forEach(function(btns, u) {
+        getUserBadge(u).then(function(badge) {
+            if (!badge || !badge.Content) return;
+            btns.forEach(function(b) {
+                // Avoid duplicates on re-render
+                if (b.nextElementSibling && b.nextElementSibling.classList.contains('user-badge')) return;
+                var span = document.createElement('span');
+                span.className = 'badge ms-1 user-badge';
+                span.style.backgroundColor = badge.BackgroundColor;
+                span.style.color = badge.Color;
+                span.textContent = badge.Content;
+                b.insertAdjacentElement('afterend', span);
+            });
+        }).catch(function() {});
+    });
+}
+
+async function getUserBadge(username) {
+    var BADGE_TTL = 1000 * 60 * 60 * 24; // 24 h, matching XMOJ.user.js
+    var prefix = 'UserScript-User-' + username + '-Badge-';
+    var lastUpdate = localStorage.getItem(prefix + 'LastUpdateTime');
+    if (lastUpdate && (Date.now() - parseInt(lastUpdate)) < BADGE_TTL) {
+        return {
+            BackgroundColor: localStorage.getItem(prefix + 'BackgroundColor') || '',
+            Color: localStorage.getItem(prefix + 'Color') || '',
+            Content: localStorage.getItem(prefix + 'Content') || ''
+        };
+    }
+    var result = await apiCall('GetBadge', { UserID: username });
+    var badge = (result && result.Success && result.Data)
+        ? result.Data
+        : { BackgroundColor: '', Color: '', Content: '' };
+    localStorage.setItem(prefix + 'BackgroundColor', badge.BackgroundColor || '');
+    localStorage.setItem(prefix + 'Color', badge.Color || '');
+    localStorage.setItem(prefix + 'Content', badge.Content || '');
+    localStorage.setItem(prefix + 'LastUpdateTime', String(Date.now()));
+    return badge;
+}
+
+async function showUserInfo(username) {
+    var title = document.getElementById('user-info-modal-title');
+    var body = document.getElementById('user-info-modal-body');
+    var profileLink = document.getElementById('user-info-profile-link');
+    var profileUrl = XMOJ_BASE + '/userinfo.php?user=' + encodeURIComponent(username);
+
+    title.textContent = username;
+    profileLink.href = profileUrl;
+    body.innerHTML = '<div class="text-center py-3"><span class="spinner-border spinner-border-sm me-2"></span>加载中…</div>';
+    userInfoModalBS.show();
+
+    var results = await Promise.allSettled([
+        fetch(profileUrl, { referrer: XMOJ_BASE + '/', credentials: 'include' })
+            .then(function(r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.text(); }),
+        getUserBadge(username)
+    ]);
+
+    // ── Badge (render into title) ───────────────────────────────────────────
+    var badge = results[1].status === 'fulfilled' ? results[1].value : null;
+    if (badge && badge.Content) {
+        title.innerHTML = escapeHtml(username) +
+            ' <span class="badge ms-2" style="background-color:' + escapeHtml(badge.BackgroundColor) +
+            ';color:' + escapeHtml(badge.Color) + '">' + escapeHtml(badge.Content) + '</span>';
+    }
+
+    // ── Profile (render into body) ──────────────────────────────────────────
+    if (results[0].status === 'rejected') {
+        body.innerHTML = '<p class="text-body-secondary mb-0">无法加载用户信息，请直接访问资料页面。</p>';
+        return;
+    }
+
+    var html = results[0].value;
+
+    if (html.indexOf('No such User!') !== -1) {
+        body.innerHTML = '<p class="text-body-secondary mb-0">用户不存在。</p>';
+        return;
+    }
+
+    var doc = new DOMParser().parseFromString(html, 'text/html');
+
+    var captionEl = doc.querySelector('#statics > caption');
+    var nickname = '';
+    if (captionEl) {
+        // Caption text format: "UserID--Nickname"
+        var parts = captionEl.textContent.trim().split('--');
+        if (parts.length > 1) nickname = parts[1].trim();
+    }
+
+    var submitEl = doc.querySelector('#statics > tbody > tr:nth-child(3) > td:nth-child(2)');
+    var acceptEl = doc.querySelector('#statics > tbody > tr:nth-child(4) > td:nth-child(2)');
+    var submitCount = submitEl ? (parseInt(submitEl.textContent.trim()) || 0) : 0;
+    var acceptCount = acceptEl ? (parseInt(acceptEl.textContent.trim()) || 0) : 0;
+    var rating = submitCount > 0 ? ((acceptCount / submitCount) * 1000).toFixed(1) : '—';
+
+    var tbodyRows = doc.querySelectorAll('#statics > tbody > tr');
+    var email = '';
+    if (tbodyRows.length > 0) {
+        var lastCells = tbodyRows[tbodyRows.length - 1].querySelectorAll('td');
+        if (lastCells.length >= 2) email = lastCells[1].textContent.trim();
+    }
+
+    var rows = [];
+    if (nickname) rows.push(['昵称', escapeHtml(nickname)]);
+    rows.push(['评分', escapeHtml(acceptCount + ' / ' + submitCount) +
+        ' <span class="text-body-secondary small ms-1">(' + escapeHtml(String(rating)) + ')</span>']);
+    if (email) rows.push(['邮箱', '<a href="mailto:' + escapeHtml(email) + '">' + escapeHtml(email) + '</a>']);
+
+    body.innerHTML = '<dl class="row mb-0">' +
+        rows.map(function(r) {
+            return '<dt class="col-4 text-truncate">' + r[0] + '</dt>' +
+                   '<dd class="col-8 mb-2">' + r[1] + '</dd>';
+        }).join('') +
+        '</dl>';
+}
+
+function initUserButtons(container) {
+    container.querySelectorAll('.user-info-btn').forEach(function(btn) {
+        btn.addEventListener('click', function(e) {
+            e.stopPropagation();
+            showUserInfo(btn.dataset.username);
+        });
+    });
 }
 
 // ── Theme ──────────────────────────────────────────────────────────────────
@@ -487,6 +659,40 @@ async function apiCall(action, data) {
 }
 
 // ── Mail List ──────────────────────────────────────────────────────────────
+function renderMailList(query) {
+    var tbody = document.getElementById('list-tbody');
+    var q = query ? query.trim().toLowerCase() : '';
+    var list = q
+        ? mailListCache.filter(function(item) { return item.OtherUser.toLowerCase().indexOf(q) !== -1; })
+        : mailListCache;
+    if (list.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="4" class="text-center text-body-secondary py-4">' +
+            (q ? '未找到匹配的联系人' : '暂无消息') + '</td></tr>';
+        return;
+    }
+    tbody.innerHTML = list.map(function(item) {
+        var hasUnread = item.UnreadCount > 0;
+        var preview = stripMarkdown(item.LastsMessage);
+        if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
+        return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
+            '<td>' + userSpan(item.OtherUser) +
+            (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
+            '</td>' +
+            '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
+            '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
+            '<td class="text-body-secondary text-end">&#8250;</td>' +
+            '</tr>';
+    }).join('');
+    initUserButtons(tbody);
+    loadBadgesForContainer(tbody);
+    tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
+        row.addEventListener('click', function(e) {
+            if (e.target.closest('.user-info-btn')) return;
+            openThread(row.dataset.user);
+        });
+    });
+}
+
 async function loadMailList() {
     var tbody = document.getElementById('list-tbody');
     tbody.innerHTML = '<tr id="list-loading-row"><td colspan="4" class="text-center text-body-secondary py-4">' +
@@ -494,29 +700,13 @@ async function loadMailList() {
     try {
         var result = await apiCall('GetMailList', {});
         var list = result && result.Data && result.Data.MailList;
-        if (!list || list.length === 0) {
+        mailListCache = list || [];
+        if (mailListCache.length === 0) {
             tbody.innerHTML = '<tr><td colspan="4" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
             return;
         }
-        tbody.innerHTML = list.map(function(item) {
-            var hasUnread = item.UnreadCount > 0;
-            var preview = stripMarkdown(item.LastsMessage);
-            if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
-            return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
-                '<td>' + userLink(item.OtherUser) +
-                (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
-                '</td>' +
-                '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
-                '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
-                '<td class="text-body-secondary text-end">&#8250;</td>' +
-                '</tr>';
-        }).join('');
-        tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
-            row.addEventListener('click', function(e) {
-                if (e.target.tagName === 'A') return;
-                openThread(row.dataset.user);
-            });
-        });
+        var searchEl = document.getElementById('list-search');
+        renderMailList(searchEl ? searchEl.value : '');
     } catch (err) {
         tbody.innerHTML = '<tr><td colspan="4" class="text-center text-danger py-4">加载失败：' + escapeHtml(err.message) + '</td></tr>';
         showToast('加载消息列表失败：' + err.message, 'danger');
@@ -556,18 +746,27 @@ async function loadThread() {
             var isUnread = !m.IsRead;
             var isHighlight = isUnread && m.FromUser !== currentUser.username;
             return '<tr class="' + (isHighlight ? 'table-primary' : '') + '">' +
-                '<td class="text-nowrap">' + userLink(m.FromUser) + '</td>' +
+                '<td class="text-nowrap">' + userSpan(m.FromUser) + '</td>' +
                 '<td class="msg-bubble-cell">' + renderMarkdown(m.Content) + '</td>' +
                 '<td class="text-nowrap text-body-secondary small">' + formatTime(m.SendTime) + '</td>' +
                 '<td class="text-nowrap small">' + (isUnread ? '<span class="badge text-bg-warning">未读</span>' : '<span class="text-body-secondary">已读</span>') + '</td>' +
                 '</tr>';
         }).join('');
-        // Make images clickable
+        initUserButtons(tbody);
+        loadBadgesForContainer(tbody);
+        // Make images clickable to zoom
         tbody.querySelectorAll('img').forEach(function(img) {
+            img.title = '点击放大';
             img.addEventListener('click', function() {
                 document.getElementById('img-modal-src').src = img.src;
                 imgModalBS.show();
             });
+            // Re-scroll after each image loads so the bottom stays in view
+            if (atBottom) {
+                img.addEventListener('load', function() {
+                    scrollEl.scrollTop = scrollEl.scrollHeight;
+                });
+            }
         });
         // Make links open in new tab
         tbody.querySelectorAll('a').forEach(function(a) {
@@ -575,7 +774,11 @@ async function loadThread() {
             a.setAttribute('rel', 'noopener noreferrer');
         });
         if (atBottom) {
-            scrollEl.scrollTop = scrollEl.scrollHeight;
+            // Use requestAnimationFrame so the browser has finished laying out
+            // the new rows before we read scrollHeight
+            requestAnimationFrame(function() {
+                scrollEl.scrollTop = scrollEl.scrollHeight;
+            });
         }
         isFirstLoad = false;
     } catch (err) {
@@ -722,13 +925,17 @@ function checkSessionHash() {
 }
 
 // ── Login Tabs ─────────────────────────────────────────────────────────────
+function setLoginTab(tab) {
+    document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) {
+        b.classList.toggle('active', b.dataset.tab === tab);
+    });
+    document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
+    document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
+}
+
 document.querySelectorAll('#loginTabs .nav-link').forEach(function(btn) {
     btn.addEventListener('click', function() {
-        document.querySelectorAll('#loginTabs .nav-link').forEach(function(b) { b.classList.remove('active'); });
-        btn.classList.add('active');
-        var tab = btn.dataset.tab;
-        document.getElementById('tab-bookmarklet').style.display = tab === 'bookmarklet' ? '' : 'none';
-        document.getElementById('tab-manual').style.display = tab === 'manual' ? '' : 'none';
+        setLoginTab(btn.dataset.tab);
     });
 });
 
@@ -745,12 +952,18 @@ document.getElementById('btn-logout').addEventListener('click', logout);
 
 document.getElementById('btn-refresh-list').addEventListener('click', loadMailList);
 
+document.getElementById('list-search').addEventListener('input', function() {
+    renderMailList(this.value);
+});
+
 document.getElementById('btn-compose-send').addEventListener('click', sendCompose);
 
 document.getElementById('btn-back').addEventListener('click', function() {
     stopRefresh();
     currentThread = null;
+    document.getElementById('list-search').value = '';
     showScreen('screen-list');
+    renderMailList('');
     loadMailList();
 });
 
@@ -783,6 +996,32 @@ document.getElementById('thread-compose').addEventListener('paste', function(e) 
     }
 });
 
+// Auto-resize textarea as user types
+(function() {
+    var ta = document.getElementById('thread-compose');
+    function autoResize() {
+        ta.style.height = 'auto';
+        ta.style.height = Math.min(ta.scrollHeight, 200) + 'px';
+    }
+    ta.addEventListener('input', autoResize);
+    autoResize();
+})();
+
+// Global paste handler: upload image from clipboard when in thread view
+document.addEventListener('paste', function(e) {
+    if (document.getElementById('screen-thread').style.display === 'none') return;
+    if (e.defaultPrevented) return; // already handled by local handler
+    var items = e.clipboardData && e.clipboardData.items;
+    if (!items) return;
+    for (var i = 0; i < items.length; i++) {
+        if (items[i].type.startsWith('image/')) {
+            e.preventDefault();
+            handleImageFile(items[i].getAsFile());
+            return;
+        }
+    }
+});
+
 document.getElementById('img-modal-src').addEventListener('click', function() {
     imgModalBS.hide();
 });
@@ -797,6 +1036,12 @@ document.addEventListener('visibilitychange', function() {
 (function init() {
     initTheme();
     initBookmarklet();
+
+    // Set default login tab: bookmarklet on desktop, session login on mobile
+    var isDesktop = window.matchMedia
+        ? window.matchMedia('(pointer: fine)').matches
+        : (!('ontouchstart' in window) && window.innerWidth >= 1024);
+    setLoginTab(isDesktop ? 'bookmarklet' : 'manual');
 
     // Check for bookmarklet redirect
     if (checkSessionHash()) {

--- a/messages.html
+++ b/messages.html
@@ -240,7 +240,7 @@
     <!-- Mail list table -->
     <div class="table-responsive">
         <table class="table table-hover table-borderless align-middle">
-            <thead class="table-light">
+            <thead>
                 <tr>
                     <th>用户</th>
                     <th>最新消息</th>
@@ -269,7 +269,7 @@
     <!-- Messages table -->
     <div id="thread-messages" class="mb-2">
         <table class="table table-hover table-borderless align-top">
-            <thead class="table-light">
+            <thead>
                 <tr>
                     <th class="text-nowrap">发送者</th>
                     <th>内容</th>

--- a/messages.html
+++ b/messages.html
@@ -549,8 +549,9 @@ async function loadThread() {
             return;
         }
         tbody.innerHTML = mails.map(function(m) {
-            var isUnread = !m.IsRead && m.FromUser !== currentUser.username;
-            return '<tr class="' + (isUnread ? 'table-primary' : '') + '">' +
+            var isUnread = !m.IsRead;
+            var isHighlight = isUnread && m.FromUser !== currentUser.username;
+            return '<tr class="' + (isHighlight ? 'table-primary' : '') + '">' +
                 '<td class="text-nowrap">' + userLink(m.FromUser) + '</td>' +
                 '<td class="msg-bubble-cell">' + renderMarkdown(m.Content) + '</td>' +
                 '<td class="text-nowrap text-body-secondary small">' + formatTime(m.SendTime) + '</td>' +

--- a/messages.html
+++ b/messages.html
@@ -456,7 +456,10 @@ async function showUserInfo(username) {
     userInfoModalBS.show();
 
     try {
-        var res = await fetch(profileUrl);
+        var res = await fetch(profileUrl, {
+            referrer: XMOJ_BASE + '/',
+            credentials: 'include'
+        });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         var html = await res.text();
 

--- a/messages.html
+++ b/messages.html
@@ -1023,6 +1023,7 @@ document.addEventListener('paste', function(e) {
 });
 
 document.getElementById('img-modal-src').addEventListener('click', function() {
+    this.blur();
     imgModalBS.hide();
 });
 

--- a/messages.html
+++ b/messages.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="light dark">
     <title>短消息 WebUI — XMOJ-Script</title>
     <link rel="icon" href="favicon.ico">
-    <link href="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.3/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         body { padding-top: 56px; }
         #thread-messages { max-height: 60vh; overflow-y: auto; }
@@ -224,9 +224,9 @@
     </div>
 </div>
 
-<script src="https://cdn.bootcdn.net/ajax/libs/twitter-bootstrap/5.3.3/js/bootstrap.bundle.min.js"></script>
-<script src="https://cdn.bootcdn.net/ajax/libs/marked/9.1.6/marked.min.js"></script>
-<script src="https://cdn.bootcdn.net/ajax/libs/dompurify/3.0.6/purify.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@9.1.6/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.6/dist/purify.min.js"></script>
 <script>
 'use strict';
 

--- a/messages.html
+++ b/messages.html
@@ -476,7 +476,8 @@ async function apiCall(action, data) {
         body: JSON.stringify({
             Authentication: { SessionID: currentUser.phpsessid, Username: currentUser.username },
             Data: data,
-            Version: WEBUI_VERSION
+            Version: WEBUI_VERSION,
+            DebugMode: false
         })
     });
     if (!res.ok) throw new Error('HTTP ' + res.status);

--- a/messages.html
+++ b/messages.html
@@ -548,6 +548,7 @@ async function loadThread() {
             tbody.innerHTML = '<tr><td colspan="4" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
             return;
         }
+        mails.sort(function(a, b) { return a.SendTime - b.SendTime; });
         tbody.innerHTML = mails.map(function(m) {
             var isUnread = !m.IsRead;
             var isHighlight = isUnread && m.FromUser !== currentUser.username;

--- a/messages.html
+++ b/messages.html
@@ -229,6 +229,12 @@
         </div>
     </div>
 
+    <!-- Search contacts -->
+    <div class="mb-2">
+        <input type="search" class="form-control form-control-sm" id="list-search"
+               placeholder="搜索联系人…" autocomplete="off" autocapitalize="none">
+    </div>
+
     <!-- Compose new message -->
     <div class="collapse mb-3" id="compose-panel">
         <div class="card card-body border-0 shadow-sm">
@@ -375,6 +381,7 @@ let currentUser    = null;   // { username, phpsessid }
 let currentThread  = null;   // other user's username
 let refreshTimer   = null;
 let isFirstLoad    = true;
+let mailListCache  = [];     // last fetched mail list (for local search)
 
 // ── Bootstrap instances ────────────────────────────────────────────────────
 const toastEl        = document.getElementById('app-toast');
@@ -591,6 +598,38 @@ async function apiCall(action, data) {
 }
 
 // ── Mail List ──────────────────────────────────────────────────────────────
+function renderMailList(query) {
+    var tbody = document.getElementById('list-tbody');
+    var q = query ? query.trim().toLowerCase() : '';
+    var list = q
+        ? mailListCache.filter(function(item) { return item.OtherUser.toLowerCase().indexOf(q) !== -1; })
+        : mailListCache;
+    if (list.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="3" class="text-center text-body-secondary py-4">' +
+            (q ? '未找到匹配的联系人' : '暂无消息') + '</td></tr>';
+        return;
+    }
+    tbody.innerHTML = list.map(function(item) {
+        var hasUnread = item.UnreadCount > 0;
+        var preview = stripMarkdown(item.LastsMessage);
+        if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
+        return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
+            '<td>' + userSpan(item.OtherUser) +
+            (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
+            '</td>' +
+            '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
+            '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
+            '</tr>';
+    }).join('');
+    initUserButtons(tbody);
+    tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
+        row.addEventListener('click', function(e) {
+            if (e.target.closest('.user-info-btn')) return;
+            openThread(row.dataset.user);
+        });
+    });
+}
+
 async function loadMailList() {
     var tbody = document.getElementById('list-tbody');
     tbody.innerHTML = '<tr id="list-loading-row"><td colspan="3" class="text-center text-body-secondary py-4">' +
@@ -598,29 +637,13 @@ async function loadMailList() {
     try {
         var result = await apiCall('GetMailList', {});
         var list = result && result.Data && result.Data.MailList;
-        if (!list || list.length === 0) {
+        mailListCache = list || [];
+        if (mailListCache.length === 0) {
             tbody.innerHTML = '<tr><td colspan="3" class="text-center text-body-secondary py-4">暂无消息</td></tr>';
             return;
         }
-        tbody.innerHTML = list.map(function(item) {
-            var hasUnread = item.UnreadCount > 0;
-            var preview = stripMarkdown(item.LastsMessage);
-            if (preview.length > PREVIEW_LEN) preview = preview.slice(0, PREVIEW_LEN) + '…';
-            return '<tr class="' + (hasUnread ? 'table-primary' : '') + '" data-user="' + escapeHtml(item.OtherUser) + '" style="cursor:pointer;">' +
-                '<td>' + userSpan(item.OtherUser) +
-                (hasUnread ? ' <span class="badge text-bg-danger ms-1">' + item.UnreadCount + '</span>' : '') +
-                '</td>' +
-                '<td class="text-body-secondary small">' + escapeHtml(preview) + '</td>' +
-                '<td class="text-nowrap text-body-secondary small">' + formatTime(item.SendTime) + '</td>' +
-                '</tr>';
-        }).join('');
-        initUserButtons(tbody);
-        tbody.querySelectorAll('tr[data-user]').forEach(function(row) {
-            row.addEventListener('click', function(e) {
-                if (e.target.closest('.user-info-btn')) return;
-                openThread(row.dataset.user);
-            });
-        });
+        var searchEl = document.getElementById('list-search');
+        renderMailList(searchEl ? searchEl.value : '');
     } catch (err) {
         tbody.innerHTML = '<tr><td colspan="3" class="text-center text-danger py-4">加载失败：' + escapeHtml(err.message) + '</td></tr>';
         showToast('加载消息列表失败：' + err.message, 'danger');
@@ -854,6 +877,10 @@ document.getElementById('btn-manual-login').addEventListener('click', function()
 document.getElementById('btn-logout').addEventListener('click', logout);
 
 document.getElementById('btn-refresh-list').addEventListener('click', loadMailList);
+
+document.getElementById('list-search').addEventListener('input', function() {
+    renderMailList(this.value);
+});
 
 document.getElementById('btn-compose-send').addEventListener('click', sendCompose);
 

--- a/messages.html
+++ b/messages.html
@@ -407,7 +407,9 @@ function formatTime(ts) {
     if (d.toDateString() === now.toDateString()) {
         return pad(d.getHours()) + ':' + pad(d.getMinutes());
     }
-    return (d.getMonth() + 1) + '/' + d.getDate() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+    var datePart = (d.getFullYear() !== now.getFullYear() ? d.getFullYear() + '/' : '') +
+        (d.getMonth() + 1) + '/' + d.getDate();
+    return datePart + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
 }
 
 // Popover state for user info buttons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md

Notes:
- Base your PR on the developmental branch (`dev`).
- Please use this pull request template, or your pull request will be closed.
- Use "Closes #123" to auto-link issues.
-->

<!-- If you need to add release notes, put them here.-->
<!-- release-notes
No release notes were provided for this release.
-->

**What does this PR aim to accomplish?:**

<!--- Replace this with a detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues -->

**How does this PR accomplish the above?:**

<!--- Replace this with a detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix -->

---
<!-- If you are an LLM or AI assistant filling out this template: do NOT blindly tick boxes or confirm items without actually verifying them. Read each item carefully and only confirm what you have genuinely done. For item 11 specifically, you cannot test in a browser yourself — flag this to the human and ask them to verify the changes work in both the new UI and the old/classic XMOJ UI before checking that box. -->
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code.
3. I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
10. I give this submission freely and claim no ownership to its content.
11. I have verified that my changes work correctly in **both the new UI and the old/classic UI**.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Bump XMOJ-Script to version 3.3.5, add a web-based messaging interface, introduce an optional image enlargement feature, and make several UX and styling refinements across contest, status, and ranking views.

New Features:
- Provide a standalone messages.html WebUI for viewing and sending short messages via the XMOJ-Script backend, including markdown rendering, image upload, user info modals, and dark mode support.
- Add an ImageEnlarger utility to enlarge images site-wide with zoom, pan, navigation, and download controls, configurable via the script’s feature toggles.
- Expose a contest problem list refresh control in the contest problem switcher and share contest problem list loading via a reusable GetContestProblemList helper.

Bug Fixes:
- Correct minor wording in the contest submission error message to fix a Chinese typo.

Enhancements:
- Preserve problem, language, and result filters in the NewBootstrap status search form based on current URL parameters.
- Respect the MonochromeUI setting when clearing colors in OI and Correct rank tables so color stripping is only applied when that theme is enabled.
- Disable built-in translation toggle elements on problem pages to avoid conflicts with the script UI.
- Switch the project site to load Bootstrap assets from cdnjs and surface the short-message WebUI in the navbar and feature list copy.

Build:
- Update package.json and the userscript metadata version from 3.3.0 to 3.3.5.

Documentation:
- Document the availability of the short-message WebUI for devices that cannot install user scripts in the project homepage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a standalone `messages.html` WebUI for short messages (usable on iOS and browsers without userscript) and an optional ImageEnlarger modal for viewing images. Also fixes contest problem switching, improves status filters, gates monochrome styling, and removes the problem translate buttons.

- **New Features**
  - `messages.html` WebUI: PHPSESSID or desktop bookmarklet login, inbox and threads, local contact search, user badges/info modal, image upload/paste with Markdown, zoom viewer, auto-refresh, and dark mode.
  - ImageEnlarger toggle: modal viewer with zoom/pan/reset/save, keyboard shortcuts, and click-to-open; applies to page images and ignores gravatar/cravatar sources.
  - Status page: read and validate `status.php` query params and prefill the filter form.

- **Bug Fixes**
  - Fix contest ProblemSwitcher not updating; add a "刷新" control and cache via `GetContestProblemList`.
  - Gate MonochromeUI black/white styling on contest rank pages behind the feature flag.
  - Remove problem translate buttons on `problem.php`; minor copy fix in submit flow; switch `index.html` to `cdnjs` and add a nav link to `messages.html`.

<sup>Written for commit 3ea071d63e65062e0aacae14e0a8097c13223d95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

