### PR TITLE
Revert "Update to release 3.4.0"

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3477,33 +3477,6 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
-        },
-        "3.4.0": {
-            "UpdateDate": 1774192142561,
-            "Prerelease": false,
-            "UpdateContents": [
-                {
-                    "PR": 924,
-                    "Description": "Add ImageEnlarger feature with modal viewer"
-                },
-                {
-                    "PR": 933,
-                    "Description": "Fix problem switcher not update"
-                },
-                {
-                    "PR": 937,
-                    "Description": "Display status.php Query Content"
-                },
-                {
-                    "PR": 939,
-                    "Description": "fix: gate MonochromeUI-specific styling in contestrank pages behind flag"
-                },
-                {
-                    "PR": 948,
-                    "Description": "Remove problem translate button"
-                }
-            ],
-            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.4.0
+// @version      3.3.5
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.4.0",
+  "version": "3.3.5",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
Reverts XMOJ-Script-dev/XMOJ-Script#957

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the 3.4.0 release and rolls back to 3.3.5 to restore the previous stable version. Removes the 3.4.0 entry from `Update.json` and downgrades versions in `XMOJ.user.js` and `package.json`.

<sup>Written for commit 0698aaa8c81633c835012e66e09f542f9767a354. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Build:
- Downgrade the package.json version from 3.4.0 to 3.3.5 to match the reverted release state.