### PR TITLE
feat: Add hourly periodic cloud settings sync

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3532,7 +3532,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.4.2": {
-            "UpdateDate": 1774705643181,
+            "UpdateDate": 1774706085890,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3530,6 +3530,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "3.4.2": {
+            "UpdateDate": 1774704899385,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 963,
+                    "Description": "feat: Add hourly periodic cloud settings sync"
+                }
+            ],
+            "Notes": "Add hourly automatic cloud settings sync. Every hour, if CloudSync is enabled, settings are downloaded from the cloud and applied locally, then local settings are uploaded to the cloud. This keeps settings in sync across devices without requiring a visit to the settings page."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3532,7 +3532,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.4.2": {
-            "UpdateDate": 1774704969242,
+            "UpdateDate": 1774705643181,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3532,7 +3532,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.4.2": {
-            "UpdateDate": 1774704899385,
+            "UpdateDate": 1774704969242,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -577,8 +577,8 @@ let PeriodicCloudSync = () => {
                 }
                 if (themeChanged) initTheme();
             }
+            SyncSettingsToCloud();
         }
-        SyncSettingsToCloud();
     });
 };
 
@@ -939,7 +939,7 @@ let initTheme = () => {
     }
 };
 initTheme();
-if (UtilityEnabled("CloudSync")) setInterval(PeriodicCloudSync, 60 * 60 * 1000);
+setInterval(PeriodicCloudSync, 60 * 60 * 1000);
 
 
 class NavbarStyler {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -560,6 +560,28 @@ let SyncSettingsToCloud = (CallBack) => {
     });
 };
 
+let PeriodicCloudSync = () => {
+    if (!CurrentUsername || !UtilityEnabled("CloudSync")) return;
+    RequestAPI("GetUserSettings", {}, (Response) => {
+        if (Response.Success) {
+            const cloudSettings = (Response.Data && Response.Data.Settings) || {};
+            if (Object.keys(cloudSettings).length > 0) {
+                let themeChanged = false;
+                for (let key in cloudSettings) {
+                    const rawValue = String(cloudSettings[key]);
+                    const localKey = "UserScript-Setting-" + key;
+                    if (localStorage.getItem(localKey) !== rawValue) {
+                        localStorage.setItem(localKey, rawValue);
+                        if (key === "Theme") themeChanged = true;
+                    }
+                }
+                if (themeChanged) initTheme();
+            }
+        }
+        SyncSettingsToCloud();
+    });
+};
+
 unsafeWindow.GetContestProblemList = async function(RefreshList) {
     try {
         const contestReq = await fetch("https://www.xmoj.tech/contest.php?cid=" + SearchParams.get("cid"));
@@ -917,6 +939,7 @@ let initTheme = () => {
     }
 };
 initTheme();
+if (UtilityEnabled("CloudSync")) setInterval(PeriodicCloudSync, 60 * 60 * 1000);
 
 
 class NavbarStyler {

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.4.1
+// @version      3.4.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -562,8 +562,11 @@ let SyncSettingsToCloud = (CallBack) => {
 
 let PeriodicCloudSync = () => {
     if (!CurrentUsername || !UtilityEnabled("CloudSync")) return;
+    const lastSync = parseInt(localStorage.getItem("UserScript-CloudSync-LastSync") || "0");
+    if (Date.now() - lastSync < 60 * 60 * 1000) return;
     RequestAPI("GetUserSettings", {}, (Response) => {
         if (Response.Success) {
+            localStorage.setItem("UserScript-CloudSync-LastSync", String(Date.now()));
             const cloudSettings = (Response.Data && Response.Data.Settings) || {};
             if (Object.keys(cloudSettings).length > 0) {
                 let themeChanged = false;
@@ -939,6 +942,7 @@ let initTheme = () => {
     }
 };
 initTheme();
+PeriodicCloudSync();
 setInterval(PeriodicCloudSync, 60 * 60 * 1000);
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md

Notes:
- Base your PR on the developmental branch (`dev`).
- Please use this pull request template, or your pull request will be closed.
- Use "Closes #123" to auto-link issues.
-->

<!-- If you need to add release notes, put them here.-->
<!-- release-notes
Add hourly automatic cloud settings sync. Every hour, if CloudSync is enabled, settings are downloaded from the cloud and applied locally, then local settings are uploaded to the cloud. This keeps settings in sync across devices without requiring a visit to the settings page.
-->

**What does this PR aim to accomplish?:**

Add automatic periodic (hourly) bidirectional cloud settings sync, so settings stay consistent across devices without requiring the user to manually visit the settings page.

**How does this PR accomplish the above?:**

- Adds a global `PeriodicCloudSync` function that: downloads cloud settings and applies changed values to localStorage (re-applying theme if it changed), then uploads local settings back to cloud
- Registers a `setInterval` on page load (once `initTheme` is ready) that fires every hour if CloudSync is enabled
- The per-call guard (`if (!UtilityEnabled("CloudSync")) return`) means disabling CloudSync mid-session stops further syncs immediately

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code.
3. I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
10. I give this submission freely and claim no ownership to its content.
11. ⚠️ UI compatibility in both new and classic UI has not been verified by the AI — please test this in both UIs before checking this box.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Add periodic background synchronization of user settings with the cloud and bump the script/package version.

New Features:
- Introduce an hourly periodic cloud settings sync that keeps local settings aligned with cloud settings and re-applies the theme when it changes.

Enhancements:
- Trigger an immediate cloud sync check on initialization so eligible sessions start syncing without user interaction.

Build:
- Bump script and package versions from 3.4.1 to 3.4.2 to reflect the new behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hourly background cloud settings sync with cross‑tab throttling to avoid duplicate runs across tabs and reloads. Keeps settings consistent across devices without opening the settings page.

- New Features
  - Adds `PeriodicCloudSync`: downloads cloud settings, updates `localStorage`, reapplies theme if changed, then uploads local settings only after a successful download.
  - Runs once after `initTheme`, then hourly via `setInterval`; exits immediately if `CloudSync` is disabled or no `CurrentUsername`.
  - Uses a `localStorage` timestamp to throttle sync across tabs and page loads (max once per hour).

<sup>Written for commit 3c7f746303e931ec0cf32f3371b948e63b1cc14e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

