### PR TITLE
Revert "Migrate XMOJ-BBS client endpoints to `/v1` routes"

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3541,17 +3541,6 @@
                 }
             ],
             "Notes": "Add hourly automatic cloud settings sync. Every hour, if CloudSync is enabled, settings are downloaded from the cloud and applied locally, then local settings are uploaded to the cloud. This keeps settings in sync across devices without requiring a visit to the settings page."
-        },
-        "3.4.3": {
-            "UpdateDate": 1775972372292,
-            "Prerelease": true,
-            "UpdateContents": [
-                {
-                    "PR": 969,
-                    "Description": "Migrate XMOJ-BBS client endpoints to  routes"
-                }
-            ],
-            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/Update.json
+++ b/Update.json
@@ -3541,6 +3541,17 @@
                 }
             ],
             "Notes": "Add hourly automatic cloud settings sync. Every hour, if CloudSync is enabled, settings are downloaded from the cloud and applied locally, then local settings are uploaded to the cloud. This keeps settings in sync across devices without requiring a visit to the settings page."
+        },
+        "3.4.3": {
+            "UpdateDate": 1775993022107,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 974,
+                    "Description": "Revert Migrate"
+                }
+            ],
+            "Notes": "No release notes were provided for this release."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.4.2
+// @version      3.4.3
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.4.3
+// @version      3.4.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen
@@ -505,7 +505,7 @@ let RequestAPI = (Action, Data, CallBack) => {
         }
         GM_xmlhttpRequest({
             method: "POST",
-            url: (UtilityEnabled("SuperDebug") ? "http://127.0.0.1:8787/v1/" : "https://api.xmoj-bbs.me/v1/") + Action,
+            url: (UtilityEnabled("SuperDebug") ? "http://127.0.0.1:8787/" : "https://api.xmoj-bbs.me/") + Action,
             headers: {
                 "Content-Type": "application/json",
                 "Cache-Control": "no-cache",
@@ -643,7 +643,7 @@ function ConnectNotificationSocket() {
             return;
         }
 
-        let wsUrl = (UtilityEnabled("SuperDebug") ? "ws://127.0.0.1:8787" : "wss://api.xmoj-bbs.me") + "/v1/ws/notifications?SessionID=" + Session;
+        let wsUrl = (UtilityEnabled("SuperDebug") ? "ws://127.0.0.1:8787" : "wss://api.xmoj-bbs.me") + "/ws/notifications?SessionID=" + Session;
 
         if (UtilityEnabled("DebugMode")) {
             console.log("WebSocket: Connecting to", wsUrl);
@@ -5021,7 +5021,7 @@ int main()
                                                 "Image": Reader.result
                                             }, (ResponseData) => {
                                                 if (ResponseData.Success) {
-                                                    Content.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                    Content.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                     Content.dispatchEvent(new Event("input"));
                                                 } else {
                                                     Content.value = Before + `![上传失败！` + ResponseData.Message + `]()` + After;
@@ -5277,7 +5277,7 @@ int main()
                                                     "Image": Reader.result
                                                 }, (ResponseData) => {
                                                     if (ResponseData.Success) {
-                                                        ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                        ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                         ContentElement.dispatchEvent(new Event("input"));
                                                     } else {
                                                         ContentElement.value = Before + `![上传失败！]()` + After;
@@ -5450,7 +5450,7 @@ int main()
                                                         "Image": Reader.result
                                                     }, (ResponseData) => {
                                                         if (ResponseData.Success) {
-                                                            ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                            ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                             ContentElement.dispatchEvent(new Event("input"));
                                                         } else {
                                                             ContentElement.value = Before + `![上传失败！]()` + After;
@@ -5708,7 +5708,7 @@ int main()
                                                                         "Image": Reader.result
                                                                     }, (ResponseData) => {
                                                                         if (ResponseData.Success) {
-                                                                            ContentEditor.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                                            ContentEditor.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                                             ContentEditor.dispatchEvent(new Event("input"));
                                                                         } else {
                                                                             ContentEditor.value = Before + `![上传失败！]()` + After;

--- a/messages.html
+++ b/messages.html
@@ -367,8 +367,8 @@
 'use strict';
 
 // ── Constants ──────────────────────────────────────────────────────────────
-const API_BASE          = 'https://api.xmoj-bbs.me/v1/';
-const ASSET_BASE        = 'https://assets.xmoj-bbs.me/v1/GetImage?ImageID=';
+const API_BASE          = 'https://api.xmoj-bbs.me/';
+const ASSET_BASE        = 'https://assets.xmoj-bbs.me/GetImage?ImageID=';
 const XMOJ_BASE        = 'https://www.xmoj.tech';
 const WEBUI_VERSION     = 'webui-1.0.0';
 const STORAGE_USER      = 'xmoj-msg-username';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.4.3",
+  "version": "3.4.2",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
Reverts XMOJ-Script-dev/XMOJ-Script#969

## Summary by Sourcery

Revert the previous migration of XMOJ-BBS client endpoints to `/v1` routes and restore the original non-versioned API and asset URLs.

Bug Fixes:
- Restore compatibility with existing non-versioned XMOJ-BBS API and WebSocket endpoints.
- Restore image asset URLs to the previous non-`/v1` path format.

Build:
- Revert package and userscript version numbers back to 3.4.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `/v1` migration and restores root API, WebSocket, and image paths so requests work with the current backend.

- **Bug Fixes**
  - Use `https://api.xmoj-bbs.me/` for API and `/ws/notifications` for WebSocket (no `/v1`).
  - Use `https://assets.xmoj-bbs.me/GetImage?ImageID=...` for images (no `/v1`).
  - Revert local dev URLs to non-`/v1`.
  - Update `messages.html` constants to non-`/v1` bases.
  - Keep 3.4.3 prerelease and update `Update.json` metadata (PR 974) to reflect the revert.

<sup>Written for commit eb122c8487e337fce3382f949a41a83d4b77bca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

