### PR TITLE
Revert /v1 endpoint migration

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3552,6 +3552,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "3.4.4": {
+            "UpdateDate": 1775993504358,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 975,
+                    "Description": "Revert /v1 endpoint migration"
+                }
+            ],
+            "Notes": "Revert the `/v1` endpoint migration from #969 to restore original API routes."
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.4.3
+// @version      3.4.4
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -505,7 +505,7 @@ let RequestAPI = (Action, Data, CallBack) => {
         }
         GM_xmlhttpRequest({
             method: "POST",
-            url: (UtilityEnabled("SuperDebug") ? "http://127.0.0.1:8787/v1/" : "https://api.xmoj-bbs.me/v1/") + Action,
+            url: (UtilityEnabled("SuperDebug") ? "http://127.0.0.1:8787/" : "https://api.xmoj-bbs.me/") + Action,
             headers: {
                 "Content-Type": "application/json",
                 "Cache-Control": "no-cache",
@@ -643,7 +643,7 @@ function ConnectNotificationSocket() {
             return;
         }
 
-        let wsUrl = (UtilityEnabled("SuperDebug") ? "ws://127.0.0.1:8787" : "wss://api.xmoj-bbs.me") + "/v1/ws/notifications?SessionID=" + Session;
+        let wsUrl = (UtilityEnabled("SuperDebug") ? "ws://127.0.0.1:8787" : "wss://api.xmoj-bbs.me") + "/ws/notifications?SessionID=" + Session;
 
         if (UtilityEnabled("DebugMode")) {
             console.log("WebSocket: Connecting to", wsUrl);
@@ -5021,7 +5021,7 @@ int main()
                                                 "Image": Reader.result
                                             }, (ResponseData) => {
                                                 if (ResponseData.Success) {
-                                                    Content.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                    Content.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                     Content.dispatchEvent(new Event("input"));
                                                 } else {
                                                     Content.value = Before + `![上传失败！` + ResponseData.Message + `]()` + After;
@@ -5277,7 +5277,7 @@ int main()
                                                     "Image": Reader.result
                                                 }, (ResponseData) => {
                                                     if (ResponseData.Success) {
-                                                        ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                        ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                         ContentElement.dispatchEvent(new Event("input"));
                                                     } else {
                                                         ContentElement.value = Before + `![上传失败！]()` + After;
@@ -5450,7 +5450,7 @@ int main()
                                                         "Image": Reader.result
                                                     }, (ResponseData) => {
                                                         if (ResponseData.Success) {
-                                                            ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                            ContentElement.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                             ContentElement.dispatchEvent(new Event("input"));
                                                         } else {
                                                             ContentElement.value = Before + `![上传失败！]()` + After;
@@ -5708,7 +5708,7 @@ int main()
                                                                         "Image": Reader.result
                                                                     }, (ResponseData) => {
                                                                         if (ResponseData.Success) {
-                                                                            ContentEditor.value = Before + `![](https://assets.xmoj-bbs.me/v1/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
+                                                                            ContentEditor.value = Before + `![](https://assets.xmoj-bbs.me/GetImage?ImageID=${ResponseData.Data.ImageID})` + After;
                                                                             ContentEditor.dispatchEvent(new Event("input"));
                                                                         } else {
                                                                             ContentEditor.value = Before + `![上传失败！]()` + After;

--- a/messages.html
+++ b/messages.html
@@ -367,8 +367,8 @@
 'use strict';
 
 // ── Constants ──────────────────────────────────────────────────────────────
-const API_BASE          = 'https://api.xmoj-bbs.me/v1/';
-const ASSET_BASE        = 'https://assets.xmoj-bbs.me/v1/GetImage?ImageID=';
+const API_BASE          = 'https://api.xmoj-bbs.me/';
+const ASSET_BASE        = 'https://assets.xmoj-bbs.me/GetImage?ImageID=';
 const XMOJ_BASE        = 'https://www.xmoj.tech';
 const WEBUI_VERSION     = 'webui-1.0.0';
 const STORAGE_USER      = 'xmoj-msg-username';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!-- release-notes
Revert the `/v1` endpoint migration from #969 to restore original API routes.
-->

**What does this PR aim to accomplish?:**

Reverts the `/v1` API route prefix changes introduced in #969, while keeping the version metadata bump to 3.4.3.

**How does this PR accomplish the above?:**

Removes the `/v1/` prefix from all backend API endpoints in `XMOJ.user.js` and `messages.html`:
- `RequestAPI` URL (line 508)
- WebSocket notification URL (line 646)
- 4 image upload asset URLs (lines 5024, 5280, 5453, 5711)
- `API_BASE` and `ASSET_BASE` constants in `messages.html`

Version metadata (`@version 3.4.3`, `package.json`, `Update.json`) is intentionally preserved.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template.
2. I have commented on my proposed changes within the code.
3. I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
6. I have squashed any insignificant commits.
7. I have checked that another pull request for this purpose does not exist.
8. I have considered and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
10. I give this submission freely and claim no ownership to its content.
11. **Note:** AI cannot verify UI compatibility in both new and classic UI — please verify manually before merging.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Revert the `/v1` API and asset URL prefix changes to restore compatibility with the original backend routes while keeping the current version metadata intact.

Bug Fixes:
- Restore API request and WebSocket notification endpoints to use the original non-versioned base URLs.
- Update image upload and asset URLs to point back to the non-versioned asset service endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the /v1 endpoint migration and restores the original API and asset routes. Removes /v1 from API base, WebSocket notifications path, and image asset URLs in `XMOJ.user.js` and `messages.html`; updates version to 3.4.4 (userscript and `package.json`) and adds a 3.4.4 entry in `Update.json`.

<sup>Written for commit 57467ea763c15a5bb9dd5cdaea71f08bf1c64578. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

