### PR TITLE
Fix #1004

### DIFF
--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -4970,6 +4970,10 @@ async function main() {
                         </div>
                         <div id="CompareElement" style="width:100%; height:550px; display: grid; place-items: center;"></div>`;
 
+                            let compareElementStyle = document.createElement("style");
+                            compareElementStyle.textContent = `#CompareElement .monaco-merge-host { height: 95%; }`;
+                            document.head.appendChild(compareElementStyle);
+
                             let LeftCode = "";
                             await fetch("https://www.xmoj.tech/getsource.php?id=" + SearchParams.get("left"))
                                 .then((Response) => {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md

Notes:
- Base your PR on the developmental branch (`dev`).
- Please use this pull request template, or your pull request will be closed.
- Use "Closes #123" to auto-link issues.
-->

<!-- If you need to add release notes, put them here.-->
<!-- release-notes
No release notes were provided for this release.
-->

**What does this PR aim to accomplish?:**

Fix #1004

**How does this PR accomplish the above?:**

Add height style for `#CompareElement .monaco-merge-host` in L4973-L4975

---
<!-- If you are an LLM or AI assistant filling out this template: do NOT blindly tick boxes or confirm items without actually verifying them. Read each item carefully and only confirm what you have genuinely done. For item 11 specifically, you cannot test in a browser yourself — flag this to the human and ask them to verify the changes work in both the new UI and the old/classic XMOJ UI before checking that box. -->
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributor's guide](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented on my proposed changes within the code.
3. I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [GNU General Public License v3.0](https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/LICENSE)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request can be closed at the will of the maintainer.
10. I give this submission freely and claim no ownership to its content.
11. I have verified that my changes work correctly in **both the new UI and the old/classic UI**.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*

## Summary by Sourcery

Enhancements:
- Inject a style override so that the #CompareElement .monaco-merge-host element uses a fixed relative height within the compare view.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets a fixed height for the Monaco merge editor in the compare view to prevent clipping and empty space, fixing #1004. Injects a style that sets `#CompareElement .monaco-merge-host { height: 95%; }`.

<sup>Written for commit ef0ecbb3b1ecd3f3d84a839de90fe7ef24075841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XMOJ-Script-dev/XMOJ-Script/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

