### PR TITLE
fix: handle PID 0 submission rows

### DIFF
--- a/Update.json
+++ b/Update.json
@@ -3696,7 +3696,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.6.2": {
-            "UpdateDate": 1787286673708,
+            "UpdateDate": 1787290584604,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3696,7 +3696,7 @@
             "Notes": "No release notes were provided for this release."
         },
         "3.6.2": {
-            "UpdateDate": 1787282578221,
+            "UpdateDate": 1787286673708,
             "Prerelease": true,
             "UpdateContents": [
                 {

--- a/Update.json
+++ b/Update.json
@@ -3694,6 +3694,17 @@
                 }
             ],
             "Notes": "No release notes were provided for this release."
+        },
+        "3.6.2": {
+            "UpdateDate": 1787282578221,
+            "Prerelease": true,
+            "UpdateContents": [
+                {
+                    "PR": 1013,
+                    "Description": "fix: handle PID 0 submission rows"
+                }
+            ],
+            "Notes": "修复提交记录中题目 ID 为 0 时的排版错误。"
         }
     }
 }

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         XMOJ
-// @version      3.6.1
+// @version      3.6.2
 // @description  XMOJ增强脚本
 // @author       @XMOJ-Script-dev, @langningchen and the community
 // @namespace    https://github/langningchen

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3502,7 +3502,12 @@ async function main() {
                             SolutionIDs.push(SID);
                             if (UtilityEnabled("ResetType")) {
                                 Temp[i].childNodes[0].remove();
-                                Temp[i].childNodes[0].innerHTML = "<a href=\"https://www.xmoj.tech/showsource.php?id=" + SID + "\">" + SID + "</a> " + "<a href=\"" + Temp[i].childNodes[6].children[1].href + "\">重交</a>";
+                                let resubmitLink = Temp[i].childNodes[6].children[1];
+                                Temp[i].childNodes[0].innerHTML = "<a href=\"https://www.xmoj.tech/showsource.php?id=" + SID + "\">" + SID + "</a>";
+                                // Submissions with PID 0 do not have a resubmit link.
+                                if (resubmitLink != null) {
+                                    Temp[i].childNodes[0].innerHTML += " <a href=\"" + resubmitLink.href + "\">重交</a>";
+                                }
                                 Temp[i].childNodes[1].remove();
                                 Temp[i].childNodes[1].children[0].removeAttribute("class");
                                 Temp[i].childNodes[3].childNodes[0].innerText = SizeToStringSize(Temp[i].childNodes[3].childNodes[0].innerText);

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3502,11 +3502,19 @@ async function main() {
                             SolutionIDs.push(SID);
                             if (UtilityEnabled("ResetType")) {
                                 Temp[i].childNodes[0].remove();
-                                let resubmitLink = Temp[i].childNodes[6].children[1];
-                                Temp[i].childNodes[0].innerHTML = "<a href=\"https://www.xmoj.tech/showsource.php?id=" + SID + "\">" + SID + "</a>";
+                                let resubmitLink = Temp[i].childNodes[6]?.children[1];
+                                let sourceCell = Temp[i].childNodes[0];
+                                let sourceLink = document.createElement("a");
+                                sourceLink.href = "https://www.xmoj.tech/showsource.php?id=" + SID;
+                                sourceLink.innerText = SID;
+                                sourceCell.replaceChildren(sourceLink);
                                 // Submissions with PID 0 do not have a resubmit link.
                                 if (resubmitLink != null) {
-                                    Temp[i].childNodes[0].innerHTML += " <a href=\"" + resubmitLink.href + "\">重交</a>";
+                                    let newResubmitLink = document.createElement("a");
+                                    newResubmitLink.href = resubmitLink.href;
+                                    newResubmitLink.innerText = "重交";
+                                    sourceCell.appendChild(document.createTextNode(" "));
+                                    sourceCell.appendChild(newResubmitLink);
                                 }
                                 Temp[i].childNodes[1].remove();
                                 Temp[i].childNodes[1].children[0].removeAttribute("class");

--- a/XMOJ.user.js
+++ b/XMOJ.user.js
@@ -3502,7 +3502,7 @@ async function main() {
                             SolutionIDs.push(SID);
                             if (UtilityEnabled("ResetType")) {
                                 Temp[i].childNodes[0].remove();
-                                let resubmitLink = Temp[i].childNodes[6]?.children[1];
+                                let resubmitLink = Temp[i].childNodes[6].children[1] ?? null;
                                 let sourceCell = Temp[i].childNodes[0];
                                 let sourceLink = document.createElement("a");
                                 sourceLink.href = "https://www.xmoj.tech/showsource.php?id=" + SID;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmoj-script",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "an improvement script for xmoj.tech",
   "main": "AddonScript.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for contributing to the XMOJ-Script Community!

Please read the contributor's guide:
https://github.com/XMOJ-Script-dev/XMOJ-Script/blob/dev/CONTRIBUTING.md
-->

<!-- release-notes
修复提交记录中题目 ID 为 0 时的排版错误。
-->

**What does this PR aim to accomplish?:**

Fixes the submission-history layout failure reported in #1012.

This is the same PID 0 edge case previously discussed in #16, which was closed without a defensive rendering fix.

Closes #1012

**How does this PR accomplish the above?:**

PID 0 submission rows do not contain the usual resubmit anchor. The `ResetType` layout code previously accessed that missing anchor's `.href`, throwing an exception and stopping the remaining row transformations.

This change:

- always renders the source link;
- renders “重交” only when the resubmit anchor exists;
- preserves the existing output for ordinary submission rows.

Static verification performed:

- the complete userscript parses successfully;
- the previous unsafe `children[1].href` dereference is absent;
- the branch is one commit ahead of and zero commits behind `dev`;
- only `XMOJ.user.js` is changed (6 additions, 1 deletion).

Browser verification is still needed for both the new and classic XMOJ interfaces, so this PR is intentionally opened as a draft.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the contributor's guide and this template.
2. The non-obvious PID 0 condition is documented in the code.
3. Static checks have been completed; browser testing remains outstanding.
4. I am willing to help maintain this change if issues arise.
5. It is compatible with the GNU General Public License v3.0.
6. The change contains one focused commit.
7. I checked that no other open PR targets this issue.
8. The fix prevents one malformed row from breaking the entire submission table.
9. I accept that maintainers may decline the change.
10. The submission is given freely without ownership claims.
11. New/classic UI browser verification has not yet been completed.

---
- [ ] I have read the above and my PR is ready for review. *Left unchecked until browser verification is completed.*

## Summary by Sourcery

Handle PID 0 submission rows safely so one malformed row no longer interrupts submission-history rendering.

Bug Fixes:
- Prevent submission-history rendering from failing when rows with PID 0 lack a resubmit link.
- Preserve source-link rendering while showing the “重交” link only for submissions that support resubmission.

Build:
- Bump the userscript and package versions to 3.6.2.

Chores:
- Update release metadata in Update.json.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes submission-history crashes for PID 0 rows by building links with the DOM and guarding a missing resubmit link. Previously we concatenated innerHTML and read children[1].href unconditionally; now we always render the source link and append “重交” only when a resubmit link exists, leaving normal rows unchanged.

- Update `XMOJ.user.js` to use DOM-built anchors and a scoped null check for the resubmit link.
- Bump version to 3.6.2 and refresh `Update.json` prerelease timestamp and notes; no config or migration required. Addresses #1012.
- Verify in classic and new UIs: PID 0 rows show only the source link; other rows show source + “重交”.

<sup>Written for commit b3b0aa4624f76723d59cdcb1eeb48dc5e3d20f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/XMOJ-Script-dev/XMOJ-Script/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

